### PR TITLE
gRPC message response parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const customerId = "1234567890";
 async function example() {
   // 2. Load a Google Ads service
   const service = client.getService("GoogleAdsService");
-  
+
   // 3. Create a request
   const request = new SearchGoogleAdsRequest();
   request.setQuery(`
@@ -89,14 +89,14 @@ async function example() {
   `);
   request.setCustomerId(customerId);
   request.setPageSize(12);
-  
+
   // 4. Get the results
   const result: SearchGoogleAdsResponse = await service.search(request)
     .catch((err: Error) => {
       console.log("--- Error in search ---");
       console.log(err);
     });
-  
+
   // 5. Inspect the data!
   for (const row of res.getResultsList()) {
     const campaign: Campaign = row.getCampaign() as Campaign;
@@ -143,18 +143,22 @@ const client = new GoogleAdsClient({
 ```
 
 ### Services
+
 To load a Google Ads service, simply use the `getService` method. It supports a single string, being the name of the service. For a full list of avaiable services, check out the [Google Ads service reference](https://developers.google.com/google-ads/api/reference/rpc/google.ads.googleads.v0.services).
+
 ```javascript
 const service = client.getService("AdGroupAdService");
 ```
+
 From here, you can then use all the available methods for the service e.g. `getAdGroupAd()` and `mutateAdGroupAds()`. The parameters and return value match the format specified in the Google Ads documentation.
 
 ```javascript
-import { GetAdGroupRequest } from "google-ads-node"
+import { GetAdGroupRequest } from "google-ads-node";
 
-const request = new GetAdGroupAdRequest()
-const ad = await service.getAdGroupAd(request)
+const request = new GetAdGroupAdRequest();
+const ad = await service.getAdGroupAd(request);
 ```
+
 **Note:** Service methods use `camelCase` in this library, whereas the Google Ads documentation uses `TitleCase`, so if a service method was called `GetCampaign()`, in this library it would be `getCampaign()`
 
 ## Changelog

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./lib/client";
 export * from "./lib/types";
+export { formatCallResults } from "./lib/utils";

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -35,4 +35,4 @@ test("proto object result is generated from field mask", () => {
   ]);
 });
 
-test("proto object result can be parsed for deeply nested entities", () => {});
+// test("proto object result can be parsed for deeply nested entities", () => {});

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -1,0 +1,38 @@
+import { formatCallResults } from "./utils";
+
+test("proto object result is generated from field mask", () => {
+  const fakeResponse = [
+    {
+      campaign: {
+        resourceName: "customers/123/campaigns/123",
+        id: { value: 123 },
+        targetCpa: undefined,
+        name: { value: "<campaign-name>" },
+        status: 0,
+        manualCpc: undefined,
+        manualCpv: undefined,
+      },
+      metrics: {
+        cost: { value: 100 },
+        clicks: undefined,
+      },
+    },
+  ];
+  const fieldMask = { pathsList: ["campaign.id", "campaign.name", "metrics.cost"] };
+  const parsedResults = formatCallResults(fakeResponse, fieldMask);
+
+  expect(parsedResults).toEqual([
+    {
+      campaign: {
+        resourceName: "customers/123/campaigns/123",
+        id: 123,
+        name: "<campaign-name>",
+      },
+      metrics: {
+        cost: 100,
+      },
+    },
+  ]);
+});
+
+test("proto object result can be parsed for deeply nested entities", () => {});

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -1,13 +1,13 @@
 import { formatCallResults } from "./utils";
 
-test("proto object result is generated from field mask", () => {
+test("proto object result is parsed from field mask", () => {
   const fakeResponse = [
     {
       campaign: {
         resourceName: "customers/123/campaigns/123",
         id: { value: 123 },
         targetCpa: undefined,
-        name: { value: "<campaign-name>" },
+        name: { value: "2019" },
         status: 0,
         manualCpc: undefined,
         manualCpv: undefined,
@@ -18,21 +18,245 @@ test("proto object result is generated from field mask", () => {
       },
     },
   ];
-  const fieldMask = { pathsList: ["campaign.id", "campaign.name", "metrics.cost"] };
+  const fieldMask = {
+    pathsList: ["campaign.id", "campaign.name", "metrics.cost"],
+  };
   const parsedResults = formatCallResults(fakeResponse, fieldMask);
 
-  expect(parsedResults).toEqual([
+  expect(parsedResults).toStrictEqual([
     {
       campaign: {
         resourceName: "customers/123/campaigns/123",
         id: 123,
-        name: "<campaign-name>",
+        name: "2019",
       },
       metrics: {
         cost: 100,
       },
     },
   ]);
+  expect(Object.keys(parsedResults[0].campaign)[0]).toEqual("resourceName");
 });
 
-// test("proto object result can be parsed for deeply nested entities", () => {});
+test("proto object result can be parsed for deeply nested entities", () => {
+  const fieldMask = {
+    pathsList: [
+      "campaign.id",
+      "campaign.name",
+      "ad_group.id",
+      "ad_group.name",
+      "ad_group_criterion.criterion_id",
+      "ad_group_criterion.keyword.text",
+      "ad_group_criterion.keyword.match_type",
+      "metrics.impressions",
+      "metrics.clicks",
+      "metrics.cost_micros",
+    ],
+  };
+  const parsedResults = formatCallResults(JSON.parse(fakeKeywordResponse), fieldMask);
+
+  expect(parsedResults).toEqual([
+    {
+      campaign: {
+        resourceName: "customers/9262111890/campaigns/1473765780",
+        id: 1473765780,
+        name: "test-campaign-2 (created during library test)",
+      },
+      adGroup: {
+        resourceName: "customers/9262111890/adGroups/59960230227",
+        id: 59960230227,
+        name: "new name",
+      },
+      adGroupCriterion: {
+        resourceName: "customers/9262111890/adGroupCriteria/59960230227_10234981",
+        criterionId: 10234981,
+        keyword: {
+          text: "hello",
+          matchType: 4,
+        },
+      },
+      metrics: {
+        clicks: 0,
+        costMicros: 0,
+        impressions: 0,
+      },
+    },
+    {
+      campaign: {
+        resourceName: "customers/9262111890/campaigns/1485014801",
+        id: 1485014801,
+        name: "Test Campaign - DO NOT REMOVE",
+      },
+      adGroup: {
+        resourceName: "customers/9262111890/adGroups/60170225920",
+        id: 60170225920,
+        name: "Test AdGroup (Keywords) - DO NOT REMOVE",
+      },
+      adGroupCriterion: {
+        resourceName: "customers/9262111890/adGroupCriteria/60170225920_480628692166",
+        criterionId: 480628692166,
+        keyword: {
+          text: "test-keyword-4",
+          matchType: 4,
+        },
+      },
+      metrics: {
+        clicks: 0,
+        costMicros: 0,
+        impressions: 0,
+      },
+    },
+  ]);
+});
+
+const fakeKeywordResponse = `
+  [
+    {
+      "adGroup": {
+        "resourceName": "customers/9262111890/adGroups/59960230227",
+        "id": {
+          "value": 59960230227
+        },
+        "name": {
+          "value": "new name"
+        },
+        "status": 0,
+        "type": 0,
+        "adRotationMode": 0,
+        "urlCustomParametersList": [],
+        "displayCustomBidDimension": 0,
+        "effectiveTargetCpaSource": 0,
+        "effectiveTargetRoasSource": 0
+      },
+      "adGroupCriterion": {
+        "resourceName": "customers/9262111890/adGroupCriteria/59960230227_10234981",
+        "criterionId": {
+          "value": 10234981
+        },
+        "status": 0,
+        "type": 0,
+        "effectiveCpcBidSource": 0,
+        "effectiveCpmBidSource": 0,
+        "effectiveCpvBidSource": 0,
+        "effectivePercentCpcBidSource": 0,
+        "finalUrlsList": [],
+        "urlCustomParametersList": [],
+        "keyword": {
+          "text": {
+            "value": "hello"
+          },
+          "matchType": 4
+        }
+      },
+      "campaign": {
+        "resourceName": "customers/9262111890/campaigns/1473765780",
+        "id": {
+          "value": 1473765780
+        },
+        "name": {
+          "value": "test-campaign-2 (created during library test)"
+        },
+        "status": 0,
+        "servingStatus": 0,
+        "adServingOptimizationStatus": 0,
+        "advertisingChannelType": 0,
+        "advertisingChannelSubType": 0,
+        "urlCustomParametersList": [],
+        "biddingStrategyType": 0,
+        "frequencyCapsList": [],
+        "videoBrandSafetySuitability": 0
+      },
+      "keywordView": {
+        "resourceName": "customers/9262111890/keywordViews/59960230227_10234981"
+      },
+      "metrics": {
+        "clicks": {
+          "value": 0
+        },
+        "costMicros": {
+          "value": 0
+        },
+        "historicalCreativeQualityScore": 0,
+        "historicalLandingPageQualityScore": 0,
+        "historicalSearchPredictedCtr": 0,
+        "impressions": {
+          "value": 0
+        },
+        "interactionEventTypesList": []
+      }
+    },
+    {
+      "adGroup": {
+        "resourceName": "customers/9262111890/adGroups/60170225920",
+        "id": {
+          "value": 60170225920
+        },
+        "name": {
+          "value": "Test AdGroup (Keywords) - DO NOT REMOVE"
+        },
+        "status": 0,
+        "type": 0,
+        "adRotationMode": 0,
+        "urlCustomParametersList": [],
+        "displayCustomBidDimension": 0,
+        "effectiveTargetCpaSource": 0,
+        "effectiveTargetRoasSource": 0
+      },
+      "adGroupCriterion": {
+        "resourceName": "customers/9262111890/adGroupCriteria/60170225920_480628692166",
+        "criterionId": {
+          "value": 480628692166
+        },
+        "status": 0,
+        "type": 0,
+        "effectiveCpcBidSource": 0,
+        "effectiveCpmBidSource": 0,
+        "effectiveCpvBidSource": 0,
+        "effectivePercentCpcBidSource": 0,
+        "finalUrlsList": [],
+        "urlCustomParametersList": [],
+        "keyword": {
+          "text": {
+            "value": "test-keyword-4"
+          },
+          "matchType": 4
+        }
+      },
+      "campaign": {
+        "resourceName": "customers/9262111890/campaigns/1485014801",
+        "id": {
+          "value": 1485014801
+        },
+        "name": {
+          "value": "Test Campaign - DO NOT REMOVE"
+        },
+        "status": 0,
+        "servingStatus": 0,
+        "adServingOptimizationStatus": 0,
+        "advertisingChannelType": 0,
+        "advertisingChannelSubType": 0,
+        "urlCustomParametersList": [],
+        "biddingStrategyType": 0,
+        "frequencyCapsList": [],
+        "videoBrandSafetySuitability": 0
+      },
+      "keywordView": {
+        "resourceName": "customers/9262111890/keywordViews/60170225920_480628692166"
+      },
+      "metrics": {
+        "clicks": {
+          "value": 0
+        },
+        "costMicros": {
+          "value": 0
+        },
+        "historicalCreativeQualityScore": 0,
+        "historicalLandingPageQualityScore": 0,
+        "historicalSearchPredictedCtr": 0,
+        "impressions": {
+          "value": 0
+        },
+        "interactionEventTypesList": []
+      }
+    }
+  ]`;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,3 +27,48 @@ export function promisifyServiceClient(client: Client) {
     };
   });
 }
+
+interface FieldMask {
+  pathsList: string[];
+}
+
+export function formatCallResults(resultsList: any[], fieldMask: FieldMask) {
+  const parsedResults: any[] = [];
+  const { pathsList } = fieldMask;
+
+  for (const result of resultsList) {
+    const parsedEntity: any = {};
+
+    for (const path of pathsList) {
+      const nodes = path.split(".");
+      const firstPath = nodes[0];
+
+      nodes.shift();
+
+      if (!parsedEntity[firstPath]) {
+        parsedEntity[firstPath] = {};
+        if (result[firstPath].hasOwnProperty("resourceName")) {
+          parsedEntity[firstPath].resourceName = result[firstPath].resourceName;
+        }
+      }
+
+      for (const node of nodes) {
+        parsedEntity[firstPath][node] = result[firstPath][node].value;
+      }
+    }
+
+    parsedResults.push(parsedEntity);
+  }
+
+  return parsedResults;
+}
+
+// function getNestedObject(obj: any, path: string[]) {
+//   let index = 0;
+//   const length = path.length;
+
+//   while (obj != null && index < length) {
+//     obj = obj[path[index++]];
+//   }
+//   return index && index === length ? obj : undefined;
+// }

--- a/tslint.json
+++ b/tslint.json
@@ -14,7 +14,7 @@
       "allow-leading-underscore",
       "allow-snake-case"
     ],
-    "max-classes-per-file": [true, 3],
+    "max-classes-per-file": [true, 4],
     "ordered-imports": [
       true,
       {


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
This adds the optional ability to format all service call responses as objects, with the specified field masks. To enabled gRPC response parsing, you must use the new client option `parseResults`, and set it to `true`.

* **What is the current behavior?** 
An entire entity is returned, includes non specified fields with `undefined` values

- **What is the new behavior (if this is a feature change)?**
Only the specified fields are returned for an entity, with the nested `value` property removed e.g. `{ cost: { value: 200 }}` becomes `{ cost: 200 }`