### PR TITLE
fix(utils): handle array-type fields correctly for getFieldMask method

### DIFF
--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -242,12 +242,14 @@ test("update mask can be generated from a resource object", () => {
         something: "value",
       },
     },
+    some_list: ["foo", "bar", "baz"]
   };
   const mask = getFieldMask(resource);
   expect(mask.toObject().pathsList).toEqual([
     "amount_micros",
     "status",
     "settings.another_setting.something",
+    "some_list",
   ]);
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -197,7 +197,7 @@ function recursiveFieldMaskSearch(data: any) {
     }
     const value = data[key];
 
-    if (typeof value === "object") {
+    if (typeof value === "object" && !Array.isArray(value)) {
       const children = recursiveFieldMaskSearch(value);
       for (const child of children) {
         paths.push(`${key}.${child}`);


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

  Fix `recursiveFieldMaskSearch` to handle array-type fields correctly used for `getFieldMask` method.

* **What is the current behavior?**

  See the following case:

  ```js
  const { getFieldMask } = require('google-ads-node/build/lib/utils')

  const resource = {
    resource_name: "customers/123/campaignBudgets/321",
    amount_micros: 20000,
    status: 2,
    settings: {
      another_setting: {
        something: "value",
      },
    },
    some_list: ["foo", "bar", "baz"],
  };

  const mask = getFieldMask(resource);
  ```

  `mask.toObject().pathsList` returns `["amount_micros", "status", "settings.another_setting.something", "some_list.0", "some_list.1", "some_list.2"]`.

  The `typeof` an `array` is an `object` in JavaScript. Therefore, it will run `recursiveFieldMaskSearch()` again to try to get the children.

- **What is the new behavior (if this is a feature change)?**

  In the above example, it will return `["amount_micros", "status", "settings.another_setting.something", "some_list"]` correctly.

* **Other information**: