### PR TITLE
fix(utils): ensure all possible enums are in correct format

### DIFF
--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -145,6 +145,7 @@ test("correctly builds a keyword request from an object", () => {
   });
 
   const ad_group_criterion = {
+    status: 2,
     keyword: {
       text: 'some_keyword',
       match_type: 2,
@@ -157,6 +158,7 @@ test("correctly builds a keyword request from an object", () => {
   ) as AdGroupCriterion;
 
   expect(protobuf.toObject()).toEqual(expect.objectContaining({
+    status: 2,
     keyword: {
       text: {
         value : 'some_keyword',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -77,16 +77,23 @@ export function convertToProtoFormat(data: any, type: any): any {
       typeof value === "object" ? convertToProtoFormat(value, type) : toProtoValueFormat(value);
   }
 
-  /* Check if number values are enums (this is a bit of a hack) */
-  const err = type.verify(pb);
-  if (err && err.includes("enum value expected")) {
-    const key = err.split(":")[0];
+  /* Check if number values are enums (this is a bit of a hack) 
+      We have to run it for as many times as there are keys to ensure 
+      all possible enums are converted back to the correct format
+  */
+  Object.keys(pb).forEach(() => {
+    const err = type.verify(pb);
+    if (err && err.includes("enum value expected")) {
+      const key = err.split(":")[0];
+    
+      const enum_value = get(pb, key).value;
+    
+      set(pb, key, enum_value);
+    }
+  })
+    
 
-    const enum_value = get(pb, key).value;
-
-    set(pb, key, enum_value);
-  }
-
+  
   return pb;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,6 +172,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.set@^4.3.6":
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.6.tgz#33e635c2323f855359225df6a5c8c6f1f1908264"
+  integrity sha512-ZeGDDlnRYTvS31Laij0RsSaguIUSBTYIlJFKL3vm3T2OAZAQj2YpSvVWJc0WiG4jqg9fGX6PAPGvDqBcHfSgFg==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.123"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
@@ -3414,6 +3421,11 @@ lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.snakecase@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
Bug fix
* **What is the current behavior?**
We're checking if number values are enums only once in the convertToProtoFormat method. That means we are not converting all enums to the correct format, but only the first one.

Passing `ad_group_criterion` with two enums
```javascript
const ad_group_criterion = {
    status: 2,
    keyword: {
      text: 'some_keyword',
      match_type: 2
    }
}
```
The buildResource method will leave the second enum in the incorrect format, so the create object looks like this: 
```javascript
const ad_group_criterion = {
    status: 2,
    keyword: {
      text: 'some_keyword',
      match_type: { 
        value: 2
      }
    }
}
```
- **What is the new behavior (if this is a feature change)?**
We are checking if number values are enums for as many times as there are keys to ensure all possible enums are converted back to the correct format.
* **Other information**:
Updated buildResource test to pass 2 enums instead of one.
