### PR TITLE
 feat(client): added buildResourceUrl helper method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,15 @@ OUT_COMPILED_RESOURCES_JSON=compiled-resources.json
 OUT_STATIC_TS_ENUMS=src/lib/enums.ts
 OUT_STATIC_TS_RESOURCES=src/lib/resources.ts
 OUT_STATIC_TS_ENUM_MAPPING=src/lib/mapping.ts
+OUT_STATIC_TS_RESOURCE_NAMES=src/lib/resource-names.ts
 
 .SILENT: protos enums
 
 protos: clean compile-protos
 	$(MAKE) enums
 	$(MAKE) types
+	$(MAKE) resource-names
+	$(MAKE) fields
 	@echo "finished all"
 
 enums:
@@ -54,6 +57,9 @@ types:
 fields:
 	yarn build
 	node ./scripts/generate-fields.js
+
+resource-names:
+	node ./scripts/generate-resource-names.js $(ADS_VERSION) $(OUT_STATIC_TS_RESOURCE_NAMES)
 
 # TODO: These proto compilation steps could be cleaned up and moved to a bash script
 compile-protos:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "run-s build test:*",
     "test:lint": "tslint --project . && prettier \"src/**/*.ts\" --debug-check",
     "test:unit": "nyc jest --coverage",
-    "watch": "run-s clean build && run-p \"build:main -- -w\" \"copy-protos\" \"test:unit -- --watch --runInBand\"",
+    "watch": "run-s clean build && run-p \"build:main -- -w\" \"copy-protos\" \"test:unit -- --watch --runInBand --verbose\"",
     "version": "standard-version",
     "reset": "git clean -dfx && git reset --hard && npm i",
     "clean": "trash build test",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^13.1.0",
     "prettier": "^1.15.2",
+    "request": "^2.88.0",
     "standard-version": "^4.4.0",
     "trash-cli": "^1.4.0",
     "ts-jest": "^23.10.5",

--- a/scripts/generate-resource-names.js
+++ b/scripts/generate-resource-names.js
@@ -1,0 +1,73 @@
+const fs = require("fs");
+const request = require("request");
+
+const API_VERSION = process.argv[2];
+const OUT_FILE = process.argv[3];
+
+const DISCOVERY_URL = `https://googleads.googleapis.com/$discovery/rest?version=${API_VERSION}`;
+const RESOURCES = `GoogleAdsGoogleads${API_VERSION.toUpperCase()}Resources__`;
+const COMMON = `GoogleAdsGoogleads${API_VERSION.toUpperCase()}Common__`;
+
+const stream = fs.createWriteStream(OUT_FILE);
+
+async function main() {
+  console.log("Fetching resources from discovery api..");
+  const schema = await getDiscoverySchema();
+
+  stream.write(`export enum ResourceUrlName {`);
+
+  console.log("Compiling resource names..");
+  for (const type in schema.schemas) {
+    if (type.includes(RESOURCES)) {
+      writeResourceName(schema.schemas[type], RESOURCES);
+    }
+    if (type.includes(COMMON)) {
+      writeResourceName(schema.schemas[type], COMMON);
+    }
+  }
+
+  stream.write(`}`);
+  stream.end();
+  console.log(`Generated resource names at ${OUT_FILE}`);
+}
+
+function writeResourceName(entity, type) {
+  if (entity.properties.resourceName) {
+    const { description } = entity.properties.resourceName;
+
+    const descriptionTrimmed = description.split("\n`")[1].replace(/(\r\n|\n|\r)/gm, "");
+    const customerDelim = `customers/{customer_id}/`;
+
+    if (descriptionTrimmed && descriptionTrimmed.includes(customerDelim)) {
+      const resourceUrlName = descriptionTrimmed.split(customerDelim)[1].split("/")[0];
+      const resourceName = entity.id.replace(type, "");
+
+      stream.write(`\n// ${descriptionTrimmed}`);
+      stream.write(`\n${resourceName} = "${resourceUrlName}",\n`);
+      return;
+    }
+
+    if (descriptionTrimmed) {
+      const resourceUrlName = descriptionTrimmed.split("/")[0];
+
+      stream.write(`\n// ${descriptionTrimmed}`);
+      stream.write(`\n${entity.id.replace(type, "")} = "${resourceUrlName}",\n`);
+    }
+  }
+}
+
+function getDiscoverySchema() {
+  return new Promise((resolve, reject) => {
+    request(DISCOVERY_URL, (err, res, body) => {
+      if (err) reject(err);
+      else resolve(JSON.parse(body));
+    });
+  });
+}
+
+try {
+  main();
+} catch (err) {
+  console.log("Error compiling resource names:");
+  console.log(err);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./lib/client";
 export * from "./lib/types";
 export { getFieldMask } from "./lib/utils";
+export { ResourceUrlName } from "./lib/resource-names";

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -9,6 +9,7 @@ import {
   ResponseParsingInterceptor,
   InterceptorMethod,
 } from "./interceptor";
+import { ResourceUrlName } from "./resource-names";
 import * as services from "./services";
 import * as GrpcTypes from "./types";
 import { promisifyServiceClient, convertToProtoFormat } from "./utils";
@@ -18,6 +19,7 @@ import compiledResources from "../protos/compiled-resources.js";
 
 const DEFAULT_VERSION = "v1";
 const GOOGLE_ADS_ENDPOINT = "googleads.googleapis.com:443";
+const RESOURCE_URL_DELIMITER = "~";
 
 const PROTO_ROOT = `google.ads.googleads.${DEFAULT_VERSION}`;
 const allProtos = get(compiledResources, PROTO_ROOT);
@@ -139,6 +141,22 @@ export class GoogleAdsClient {
 
     // return { protobuf, readable };
     return protobuf;
+  }
+
+  public buildResourceUrl(
+    resource: ResourceUrlName,
+    cid?: number | string | undefined,
+    ...ids: Array<number | string>
+  ): string {
+    if (typeof cid === "undefined") {
+      const resourceUrl = `${resource}/${ids.join(RESOURCE_URL_DELIMITER)}`;
+      return resourceUrl;
+    }
+    if (resource === "customers") {
+      return `customers/${cid}`;
+    }
+    const customerResourceUrl = `customers/${cid}/${resource}/${ids.join(RESOURCE_URL_DELIMITER)}`;
+    return customerResourceUrl;
   }
 
   private buildInterceptors(): InterceptorMethod[] {

--- a/src/lib/resource-names.ts
+++ b/src/lib/resource-names.ts
@@ -1,0 +1,283 @@
+export enum ResourceUrlName {
+  // customers/{customer_id}/keywordPlanNegativeKeywords/{kp_negative_keyword_id}`
+  KeywordPlanNegativeKeyword = "keywordPlanNegativeKeywords",
+
+  // customers/{customer_id}/merchantCenterLinks/{merchant_center_id}`
+  MerchantCenterLink = "merchantCenterLinks",
+
+  // customers/{customer_id}/campaignLabels/{campaign_id}~{label_id}`
+  CampaignLabel = "campaignLabels",
+
+  // customers/{customer_id}/labels/{label_id}`
+  Label = "labels",
+
+  // customers/{customer_id}/topicViews/{ad_group_id}~{criterion_id}`
+  TopicView = "topicViews",
+
+  // customers/{customer_id}/campaignSharedSets/{campaign_id}~{shared_set_id}`
+  CampaignSharedSet = "campaignSharedSets",
+
+  // customers/{customer_id}/feedPlaceholderViews/{placeholder_type}`
+  FeedPlaceholderView = "feedPlaceholderViews",
+
+  // customers/{customer_id}/adGroupSimulations/{ad_group_id}~{type}~{modification_method}~{start_date}~{end_date}`
+  AdGroupSimulation = "adGroupSimulations",
+
+  // customers/{customer_id}/recommendations/{recommendation_id}`
+  Recommendation = "recommendations",
+
+  // customers/{customer_id}/ageRangeViews/{ad_group_id}~{criterion_id}`
+  AgeRangeView = "ageRangeViews",
+
+  // customers/{customer_id}/customerFeeds/{feed_id}`
+  CustomerFeed = "customerFeeds",
+
+  // customers/{customer_id}/paidOrganicSearchTermViews/{campaign_id}~{ad_group_id}~{URL-base64 search term}`
+  PaidOrganicSearchTermView = "paidOrganicSearchTermViews",
+
+  // customers/{customer_id}/adGroupLabels/{ad_group_id}~{label_id}`
+  AdGroupLabel = "adGroupLabels",
+
+  // customers/{customer_id}/customerManagerLinks/{manager_customer_id}~{manager_link_id}`
+  CustomerManagerLink = "customerManagerLinks",
+
+  // customers/{customer_id}/customerNegativeCriteria/{criterion_id}`
+  CustomerNegativeCriterion = "customerNegativeCriteria",
+
+  // customers/{customer_id}/remarketingActions/{remarketing_action_id}`
+  RemarketingAction = "remarketingActions",
+
+  // customers/{customer_id}/accountBudgets/{account_budget_id}`
+  AccountBudget = "accountBudgets",
+
+  // customers/{customer_id}/searchTermViews/{campaign_id}~{ad_group_id}~{URL-base64 search term}`
+  SearchTermView = "searchTermViews",
+
+  // customers/{customer_id}/genderViews/{ad_group_id}~{criterion_id}`
+  GenderView = "genderViews",
+
+  // geoTargetConstants/{geo_target_constant_id}`
+  GeoTargetConstant = "geoTargetConstants",
+
+  // languageConstants/{criterion_id}`
+  LanguageConstant = "languageConstants",
+
+  // customers/{customer_id}/dynamicSearchAdsSearchTermViews/{ad_group_id}~{search_term_fp}~{headline_fp}~{landing_page_fp}~{page_url_fp}`
+  DynamicSearchAdsSearchTermView = "dynamicSearchAdsSearchTermViews",
+
+  // customers/{customer_id}/adGroupCriterionLabels/{ad_group_id}~{criterion_id}~{label_id}`
+  AdGroupCriterionLabel = "adGroupCriterionLabels",
+
+  // customers/{customer_id}/sharedCriteria/{shared_set_id}~{criterion_id}`
+  SharedCriterion = "sharedCriteria",
+
+  // customers/{customer_id}/campaignFeeds/{campaign_id}~{feed_id}
+  CampaignFeed = "campaignFeeds",
+
+  // customers/{customer_id}/videos/{video_id}`
+  Video = "videos",
+
+  // customers/{customer_id}/adGroupCriteria/{ad_group_id}~{criterion_id}`
+  AdGroupCriterion = "adGroupCriteria",
+
+  // customers/{customer_id}/shoppingPerformanceView`
+  ShoppingPerformanceView = "shoppingPerformanceView`",
+
+  // customers/{customer_id}/adParameters/{ad_group_id}~{criterion_id}~{parameter_index}`
+  AdParameter = "adParameters",
+
+  // customers/{customer_id}/sharedSets/{shared_set_id}`
+  SharedSet = "sharedSets",
+
+  // customers/{customer_id}/biddingStrategies/{bidding_strategy_id}`
+  BiddingStrategy = "biddingStrategies",
+
+  // customers/{customer_id}/keywordPlans/{kp_plan_id}`
+  KeywordPlan = "keywordPlans",
+
+  // customers/{customer_id}/adGroupFeeds/{ad_group_id}~{feed_id}
+  AdGroupFeed = "adGroupFeeds",
+
+  // customers/{customer_id}/campaignBudgets/{budget_id}`
+  CampaignBudget = "campaignBudgets",
+
+  // customers/{customer_id}/adGroupAdLabels/{ad_group_id}~{ad_id}~{label_id}`
+  AdGroupAdLabel = "adGroupAdLabels",
+
+  // customers/{customer_id}/extensionFeedItems/{feed_item_id}`
+  ExtensionFeedItem = "extensionFeedItems",
+
+  // mobileAppCategoryConstants/{mobile_app_category_id}`
+  MobileAppCategoryConstant = "mobileAppCategoryConstants",
+
+  // customers/{customer_id}/mediaFiles/{media_file_id}`
+  MediaFile = "mediaFiles",
+
+  // customers/{customer_id}/campaignBidModifiers/{campaign_id}~{criterion_id}`
+  CampaignBidModifier = "campaignBidModifiers",
+
+  // customers/{customer_id}/adGroupAudienceViews/{ad_group_id}~{criterion_id}`
+  AdGroupAudienceView = "adGroupAudienceViews",
+
+  // googleAdsFields/{name}`
+  GoogleAdsField = "googleAdsFields",
+
+  // topicConstants/{topic_id}`
+  TopicConstant = "topicConstants",
+
+  // customers/{customer_id}/landingPageViews/{unexpanded_final_url_fingerprint}`
+  LandingPageView = "landingPageViews",
+
+  // customers/{customer_id}/campaignAudienceViews/{campaign_id}~{criterion_id}`
+  CampaignAudienceView = "campaignAudienceViews",
+
+  // customers/{customer_id}/billingSetups/{billing_setup_id}`
+  BillingSetup = "billingSetups",
+
+  // customers/{customer_id}/feedMappings/{feed_id}~{feed_mapping_id}`
+  FeedMapping = "feedMappings",
+
+  // customers/{customer_id}/groupPlacementViews/{ad_group_id}~{base64_placement}`
+  GroupPlacementView = "groupPlacementViews",
+
+  // customers/{customer_id}/geographicViews/{country_criterion_id}~{location_type}`
+  GeographicView = "geographicViews",
+
+  // customers/{customer_id}/displayKeywordViews/{ad_group_id}~{criterion_id}`
+  DisplayKeywordView = "displayKeywordViews",
+
+  // customers/{customer_id}/assets/{asset_id}`
+  Asset = "assets",
+
+  // customers/{customer_id}/campaignCriterionSimulations/{campaign_id}~{criterion_id}~{type}~{modification_method}~{start_date}~{end_date}`
+  CampaignCriterionSimulation = "campaignCriterionSimulations",
+
+  // operatingSystemVersionConstants/{criterion_id}`
+  OperatingSystemVersionConstant = "operatingSystemVersionConstants",
+
+  // customers/{customer_id}/adGroupCriterionSimulations/{ad_group_id}~{criterion_id}~{type}~{modification_method}~{start_date}~{end_date}`
+  AdGroupCriterionSimulation = "adGroupCriterionSimulations",
+
+  // customers/{customer_id}/conversionActions/{conversion_action_id}`
+  ConversionAction = "conversionActions",
+
+  // customers/{customer_id}/customInterests/{custom_interest_id}`
+  CustomInterest = "customInterests",
+
+  // customers/{customer_id}/managedPlacementViews/{ad_group_id}~{criterion_id}`
+  ManagedPlacementView = "managedPlacementViews",
+
+  // customers/{customer_id}/feeds/{feed_id}`
+  Feed = "feeds",
+
+  // customers/{customer_id}/customerExtensionSettings/{extension_type}`
+  CustomerExtensionSetting = "customerExtensionSettings",
+
+  // customers/{customer_id}/accountBudgetProposals/{account_budget_proposal_id}`
+  AccountBudgetProposal = "accountBudgetProposals",
+
+  // customers/{customer_id}/parentalStatusViews/{ad_group_id}~{criterion_id}`
+  ParentalStatusView = "parentalStatusViews",
+
+  // customers/{customer_id}/locationViews/{campaign_id}~{criterion_id}`
+  LocationView = "locationViews",
+
+  // customers/{customer_id}/mutateJobs/{mutate_job_id}`
+  MutateJob = "mutateJobs",
+
+  // customers/{customer_id}/productGroupViews/{ad_group_id}~{criterion_id}`
+  ProductGroupView = "productGroupViews",
+
+  // mobileDeviceConstants/{criterion_id}`
+  MobileDeviceConstant = "mobileDeviceConstants",
+
+  // customers/{customer_id}/customerClientLinks/{client_customer_id}~{manager_link_id}`
+  CustomerClientLink = "customerClientLinks",
+
+  // customers/{customer_id}/adScheduleViews/{campaign_id}~{criterion_id}`
+  AdScheduleView = "adScheduleViews",
+
+  // customers/{customer_id}/clickViews/{date (yyyy-MM-dd)}~{gclid}`
+  ClickView = "clickViews",
+
+  // customers/{customer_id}/domainCategories/{campaign_id}~{category_base64}~{language_code}`
+  DomainCategory = "domainCategories",
+
+  // customers/{customer_id}/keywordPlanCampaigns/{kp_campaign_id}`
+  KeywordPlanCampaign = "keywordPlanCampaigns",
+
+  // customers/{customer_id}/paymentsAccounts/{payments_account_id}`
+  PaymentsAccount = "paymentsAccounts",
+
+  // customers/{customer_id}/campaignCriteria/{campaign_id}~{criterion_id}`
+  CampaignCriterion = "campaignCriteria",
+
+  // customers/{customer_id}/userLists/{user_list_id}`
+  UserList = "userLists",
+
+  // customers/{customer_id}`
+  Customer = "customers",
+
+  // carrierConstants/{criterion_id}`
+  CarrierConstant = "carrierConstants",
+
+  // customers/{customer_id}/adGroupExtensionSettings/{ad_group_id}~{extension_type}`
+  AdGroupExtensionSetting = "adGroupExtensionSettings",
+
+  // customers/{customer_id}/customerClients/{client_customer_id}`
+  CustomerClient = "customerClients",
+
+  // customers/{customer_id}/detailPlacementViews/{ad_group_id}~{base64_placement}`
+  DetailPlacementView = "detailPlacementViews",
+
+  // customers/{customer_id}/keywordPlanAdGroups/{kp_ad_group_id}`
+  KeywordPlanAdGroup = "keywordPlanAdGroups",
+
+  // productBiddingCategoryConstants/{country_code}~{level}~{id}`
+  ProductBiddingCategoryConstant = "productBiddingCategoryConstants",
+
+  // customers/{customer_id}/customerLabels/{label_id}`
+  CustomerLabel = "customerLabels",
+
+  // customers/{customer_id}/changeStatus/{change_status_id}`
+  ChangeStatus = "changeStatus",
+
+  // customers/{customer_id}/keywordViews/{ad_group_id}~{criterion_id}`
+  KeywordView = "keywordViews",
+
+  // customers/{customer_id}/campaignExtensionSettings/{campaign_id}~{extension_type}`
+  CampaignExtensionSetting = "campaignExtensionSettings",
+
+  // customers/{customer_id}/expandedLandingPageViews/{expanded_final_url_fingerprint}`
+  ExpandedLandingPageView = "expandedLandingPageViews",
+
+  // customers/{customer_id}/userInterests/{user_interest_id}`
+  UserInterest = "userInterests",
+
+  // customers/{customer_id}/feedItems/{feed_id}~{feed_item_id}`
+  FeedItem = "feedItems",
+
+  // customers/{customer_id}/adGroups/{ad_group_id}`
+  AdGroup = "adGroups",
+
+  // customers/{customer_id}/keywordPlanKeywords/{kp_ad_group_keyword_id}`
+  KeywordPlanKeyword = "keywordPlanKeywords",
+
+  // customers/{customer_id}/feedItemTargets/{feed_id}~{feed_item_id}~{feed_item_target_type}~{feed_item_target_id}`
+  FeedItemTarget = "feedItemTargets",
+
+  // customers/{customer_id}/adGroupAds/{ad_group_id}~{ad_id}`
+  AdGroupAd = "adGroupAds",
+
+  // customers/{customer_id}/adGroupBidModifiers/{ad_group_id}~{criterion_id}`
+  AdGroupBidModifier = "adGroupBidModifiers",
+
+  // customers/{customer_id}/hotelGroupViews/{ad_group_id}~{criterion_id}`
+  HotelGroupView = "hotelGroupViews",
+
+  // customers/{customer_id}/hotelPerformanceView`
+  HotelPerformanceView = "hotelPerformanceView`",
+
+  // customers/{customer_id}/campaigns/{campaign_id}`
+  Campaign = "campaigns",
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,12 +169,6 @@
 "@types/lodash.set@^4.3.6":
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.6.tgz#33e635c2323f855359225df6a5c8c6f1f1908264"
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.set@^4.3.6":
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.6.tgz#33e635c2323f855359225df6a5c8c6f1f1908264"
   integrity sha512-ZeGDDlnRYTvS31Laij0RsSaguIUSBTYIlJFKL3vm3T2OAZAQj2YpSvVWJc0WiG4jqg9fGX6PAPGvDqBcHfSgFg==
   dependencies:
     "@types/lodash" "*"
@@ -3011,10 +3005,6 @@ lodash.map@^4.5.1:
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.snakecase@^4.1.1:
@@ -4104,7 +4094,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0:
+request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A new feature for building resource urls.

* **What is the current behavior?** (You can also link to an open issue here)
Currently there is no support for building resource urls in this library.

- **What is the new behavior (if this is a feature change)?**
Adds a `buildResourceUrl` method to the client for building resource urls. This PR also includes a new compilation step for building a [resource names to urls enum](https://github.com/Opteo/google-ads-node/blob/07cb4aa07366c190f9296b511b7ae3705f07aecb/src/lib/resource-names.ts). Check out the new tests for more examples.

```javascript
const resourceName = client.buildResourceUrl(ResourceUrlName.Campaign, "123", "321")
// "customers/123/campaigns/321"

const resourceName = client.buildResourceUrl(ResourceUrlName.GeoTargetConstant, undefined, "123")
// This resource url doesn't need a cid, so it's passed in as undefined 
// "geoTargetConstants/123"

const resourceName = client.buildResourceUrl(ResourceUrlName.SearchTermView, 1, 2, 3, 4, 5)
// Any number of ids (as strings or numbers) can be passed in
// They will be delimited with the "~" as specified by Google
// "customers/1/searchTermViews/2~3~4~5"
```

In the example above, the `ResourceUrlName.Campaign` represents the value "campaigns". The new enum `ResourceUrlName` is available in the top level export:
```javascript
import { ResourceUrlName } from "google-ads-node"
```

The signature of this method is still up for debate, so feel free to suggest any changes!