### PR TITLE
fix(utils): parse fields such as userList correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/cosmiconfig": "^5.0.3",
     "@types/google-protobuf": "^3.2.7",
     "@types/lodash.camelcase": "^4.3.6",
+    "@types/lodash.snakecase": "^4.1.6",
     "@types/lodash.get": "^4.4.6",
     "@types/lodash.set": "^4.3.6",
     "@types/protobufjs": "^6.0.0",

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -271,6 +271,47 @@ test("parsing results with field mask correctly removes undefined properties", (
   expect(Object.keys(parsedResultsWithFieldMask[0].adGroupAd).includes("name")).toBeFalsy();
 });
 
+test("parsing results fields ending in 'List' works correctly", () => {
+  const fieldMask = {
+    pathsList: [
+      "ad_group_simulation.ad_group_id",
+      "ad_group_simulation.cpc_bid_point_list.points",
+      "ad_group.url_custom_parameters",
+    ],
+  };
+
+  const parsedResultsWithFieldMask = formatCallResults(fakeSimulationResponse, fieldMask);
+
+  expect(parsedResultsWithFieldMask).toEqual([
+    {
+      adGroupSimulation: {
+        resourceName:
+          "customers/2867339011/adGroupSimulations/58185498151~CPC_BID~DEFAULT~20190910~20190916",
+        adGroupId: 58185498151,
+        cpcBidPointList: {
+          points: [
+            {
+              cpcBidMicros: 6520000,
+              biddableConversions: 5.348322868347168,
+              biddableConversionsValue: 374.3826599121094,
+              clicks: 41,
+              costMicros: 149090000,
+              impressions: 696,
+              topSlotImpressions: 542,
+            },
+          ],
+        },
+      },
+      adGroup: {
+        resourceName: "customers/2867339011/adGroups/58185498151",
+        urlCustomParameters: [],
+      },
+    },
+  ]);
+  // We should not have 'name' in the parsed result
+  // expect(Object.keys(parsedResultsWithFieldMask[0].adGroupAd).includes("name")).toBeFalsy();
+});
+
 test("parsing results with no field mask correctly removes undefined properties", () => {
   const result = [
     {
@@ -652,5 +693,32 @@ const fakeAdGroupAdResponse = [
     adGroupAdLabel: undefined,
     adGroupAudienceView: undefined,
     adGroupBidModifier: undefined,
+  },
+];
+
+const fakeSimulationResponse = [
+  {
+    adGroup: {
+      resourceName: "customers/2867339011/adGroups/58185498151",
+      urlCustomParametersList: [],
+    },
+    adGroupSimulation: {
+      resourceName:
+        "customers/2867339011/adGroupSimulations/58185498151~CPC_BID~DEFAULT~20190910~20190916",
+      adGroupId: { value: 58185498151 },
+      cpcBidPointList: {
+        pointsList: [
+          {
+            cpcBidMicros: { value: 6520000 },
+            biddableConversions: { value: 5.348322868347168 },
+            biddableConversionsValue: { value: 374.3826599121094 },
+            clicks: { value: 41 },
+            costMicros: { value: 149090000 },
+            impressions: { value: 696 },
+            topSlotImpressions: { value: 542 },
+          },
+        ],
+      },
+    },
   },
 ];

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -290,6 +290,7 @@ test("parsing results fields ending in 'List' works correctly", () => {
         adGroupId: 58185498151,
         cpcBidPointList: {
           points: [
+            // This should NOT have "List" at the end of it
             {
               cpcBidMicros: 6520000,
               biddableConversions: 5.348322868347168,
@@ -304,12 +305,10 @@ test("parsing results fields ending in 'List' works correctly", () => {
       },
       adGroup: {
         resourceName: "customers/2867339011/adGroups/58185498151",
-        urlCustomParameters: [],
+        urlCustomParameters: [], // This should have "List" at the end of it
       },
     },
   ]);
-  // We should not have 'name' in the parsed result
-  // expect(Object.keys(parsedResultsWithFieldMask[0].adGroupAd).includes("name")).toBeFalsy();
 });
 
 test("parsing results with no field mask correctly removes undefined properties", () => {

--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -288,9 +288,10 @@ test("parsing results fields ending in 'List' works correctly", () => {
         resourceName:
           "customers/2867339011/adGroupSimulations/58185498151~CPC_BID~DEFAULT~20190910~20190916",
         adGroupId: 58185498151,
+        // This should end in "List" because that's how it is defined in the docs
         cpcBidPointList: {
+          // This should NOT end in "List" (even though it comes in as pointsList)
           points: [
-            // This should NOT have "List" at the end of it
             {
               cpcBidMicros: 6520000,
               biddableConversions: 5.348322868347168,
@@ -305,7 +306,7 @@ test("parsing results fields ending in 'List' works correctly", () => {
       },
       adGroup: {
         resourceName: "customers/2867339011/adGroups/58185498151",
-        urlCustomParameters: [], // This should have "List" at the end of it
+        urlCustomParameters: [],
       },
     },
   ]);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -134,8 +134,8 @@ function parseNestedEntitiesNoPath(data: any, _structs = structs) {
   }
 
   const findMatchingStruct = (key: string) => {
-    let capitalcase_key = key.charAt(0).toUpperCase() + key.slice(1);
-    let snakecase_key = snakeCase(key);
+    const capitalcase_key = key.charAt(0).toUpperCase() + key.slice(1);
+    const snakecase_key = snakeCase(key);
 
     // We need both cases because the structs.ts file exports resources in CapitalCase,
     // but the keys inside each resource are in snake_case. parseNestedEntitiesNoPath() is

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,6 +200,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.snakecase@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.snakecase/-/lodash.snakecase-4.1.6.tgz#85f2b68f67b36c39875f26484b3a78b158ebf060"
+  integrity sha512-qGTf27ncTRUhSwvxD0hzYFmelmTrzEBGvBigrLyx6PRN1rKuy0ZEK+A3X3QnW7k+CwEjIJeAM6XBN4Ay6F03IQ==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.136"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"


### PR DESCRIPTION
This is a fix for https://github.com/Opteo/google-ads-node/issues/22, where reporting fields ending in "List" aren't dealt with correctly.
