### PR TITLE
fix(parsing): parse key/value fields such as url_custom_parameters

### DIFF
--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -117,6 +117,7 @@ test("proto object result can be parsed for nested entities with arrays", async 
       "ad_group_ad.ad.final_urls",
       "ad_group.targeting_setting.target_restrictions",
       "ad_group.name",
+      "ad_group.url_custom_parameters",
     ],
   };
 
@@ -137,6 +138,7 @@ test("proto object result can be parsed for nested entities with arrays", async 
       },
       adGroup: {
         resourceName: "customers/3827277046/adGroups/37706041185",
+        urlCustomParameters: [{ key: "yy", value: "1" }],
         targetingSetting: {
           targetRestrictions: [
             { targetingDimension: 3, bidOnly: false },
@@ -167,6 +169,7 @@ test("proto object result can be parsed for nested entities with arrays", async 
       },
       adGroup: {
         resourceName: "customers/3827277046/adGroups/37706041185",
+        urlCustomParameters: [{ key: "yy", value: "1" }],
         targetingSetting: {
           targetRestrictions: [
             { targetingDimension: 3, bidOnly: false },
@@ -666,6 +669,7 @@ const fakeAdGroupResponse = [
       },
       effectiveTargetCpaMicros: undefined,
       effectiveTargetRoas: undefined,
+      urlCustomParametersList: [{ key: { value: "yy" }, value: { value: "1" } }],
     },
     adGroupAd: {
       resourceName: "customers/3827277046/adGroupAds/37706041185~170102539400",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -171,7 +171,10 @@ function parseNestedEntitiesNoPath(data: any, _structs = structs) {
     const isObject = typeof entity === "object";
     const isUndefined = typeof entity === "undefined";
     const isArray = Array.isArray(entity);
-    const isValue = isObject ? entity.hasOwnProperty("value") : false;
+    // It needs its "value" unwrapped if it is an object and has "value" as its only key.
+    const isValue = isObject
+      ? entity.hasOwnProperty("value") && Object.keys(entity).length === 1
+      : false;
 
     if (isUndefined) {
       return;


### PR DESCRIPTION
Some fields in google ads come in key/value pairs, such as:

```javascript
{ url_custom_paramters: [
    { key: 'mykey', value: 'myvalue' }, 
    { key: 'mykey2', value: 'myvalue2' }
]}
```

Our parsing tripped up on those, returning only the value. This PR makes sure it returns both the key and the value.
