### PR TITLE
fix(types): Fixed bid_modifier field definition for Campaing Criterion

### DIFF
--- a/src/lib/struct.ts
+++ b/src/lib/struct.ts
@@ -4279,7 +4279,7 @@ export const CampaignCriterion = {
   criterion_id: number,
 
   // @ts-ignore
-  bid_modifier: { value: number },
+  bid_modifier: number,
 
   // @ts-ignore
   negative: boolean,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
* **What is the current behavior?** (You can also link to an open issue here)
Couldn`t update/create CampaingCriterion with bid_modifier usage. 
https://github.com/Opteo/google-ads-node/issues/30
