### PR TITLE
fix(utils): add support for numbers in field mask path regex

### DIFF
--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -13,6 +13,7 @@ import {
   getErrorLocationPath,
   isMutationRequest,
   safeguardMutationProtobufRequest,
+  convertPathToCamelCase,
 } from "./utils";
 
 test("proto object result is parsed from field mask", () => {
@@ -504,6 +505,34 @@ test("mutation requests can be safeguarded i.e. set to validate only or operatio
     expect(message.getValidateOnly).toEqual(undefined);
     expect(message.getOperationsList()).toEqual([]);
   });
+});
+
+test("field mask paths are correctly converted to camel case format", () => {
+  const tests = [
+    ["metrics.video_quartile_100_rate", "metrics.videoQuartile100Rate"],
+    ["metrics.video_quartile_25_rate", "metrics.videoQuartile25Rate"],
+    ["metrics.video_quartile_50_rate", "metrics.videoQuartile50Rate"],
+    ["metrics.video_quartile_75_rate", "metrics.videoQuartile75Rate"],
+    ["metrics.video_views", "metrics.videoViews"],
+    ["video.title", "video.title"],
+    [
+      "ad_group_criterion.listing_group.case_value.product_bidding_category.id",
+      "adGroupCriterion.listingGroup.caseValue.productBiddingCategory.id",
+    ],
+    [
+      "ad_group_criterion.listing_group.case_value.product_bidding_category.level",
+      "adGroupCriterion.listingGroup.caseValue.productBiddingCategory.level",
+    ],
+    [
+      "metrics.all_conversions_from_interactions_rate",
+      "metrics.allConversionsFromInteractionsRate",
+    ],
+    ["invalid.some-strange-field-that-doesn't-exist", "invalid.someStrangeFieldThatDoesn'tExist"],
+  ];
+
+  for (const [input, expected] of tests) {
+    expect(convertPathToCamelCase(input)).toEqual(expected);
+  }
 });
 
 const fakeCampaignResponse = `

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -121,8 +121,8 @@ function toProtoValueFormat(value: any, struct: any, nested_path: string): any {
 }
 
 /* This is different to lodash.camelCase as it leaves any periods (".") */
-function convertPathToCamelCase(str: string) {
-  return str.replace(/([-_][a-z])/gi, $1 => {
+export function convertPathToCamelCase(str: string) {
+  return str.replace(/([-_][a-z\d])/gi, $1 => {
     return $1
       .toUpperCase()
       .replace("-", "")


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds support for parsing numbers in field mask paths correctly

* **What is the current behavior?** (You can also link to an open issue here)
When querying metrics (or any fields) with number values in the path, our current regex ignores it, and therefore removes the field in the response.

**Query**:
```sql
SELECT
    metrics.video_quartile_100_rate,
    metrics.video_quartile_25_rate,
    metrics.video_quartile_50_rate,
    metrics.video_quartile_75_rate,
    metrics.video_views,
    video.title
FROM
    video
``` 

**Current response** (video quartile metrics are missing):
```js
[
  {
    metrics: { videoViews: 420 },
    video: {
      resourceName: 'customers/123456789/videos/Vl9jUzhbTEzwWxk',
      title: 'Video Title'
    }
  }
]
```

- **What is the new behavior (if this is a feature change)?**
The regex we use for parsing the field mask now includes `\d`, which matches any digits.

**Response after this fix**:
```js
[
  {
    metrics: {
      videoQuartile100Rate: 0.26417910447761194,
      videoQuartile25Rate: 0.6373134328358209,
      videoQuartile50Rate: 0.36865671641791045,
      videoQuartile75Rate: 0.73880597014925373,
      videoViews: 420
    },
    video: {
      resourceName: 'customers/123456789/videos/Vl9jUzhbTEzwWxk',
      title: 'Video Title'
    }
  }
]
```

* **Other information**:
This is a fix for https://github.com/Opteo/google-ads-api/issues/99. I've also added some tests for the `convertPathToCamelCase` function.