### PR TITLE
fix(interceptor): parse summary row if it exists

### DIFF
--- a/src/lib/interceptor.ts
+++ b/src/lib/interceptor.ts
@@ -223,14 +223,13 @@ export class ResponseParsingInterceptor {
             results.partialFailureError.errors = formatCallResults(errors, undefined);
           }
 
-          const parsedResults = formatCallResults(
-            /* 
+          /* 
               When retrieving a single entity via a service (e.g. CampaignService), the API
               returns a single object, instead of an array
-            */
-            results.resultsList ? results.resultsList : [results],
-            results.fieldMask
-          );
+          */
+          const results_to_parse = results.resultsList ? results.resultsList : [results];
+
+          const parsedResults = formatCallResults(results_to_parse, results.fieldMask);
           if (parsedResults && results.resultsList) {
             results.resultsList = parsedResults;
           }
@@ -238,6 +237,15 @@ export class ResponseParsingInterceptor {
           if (parsedResults && !results.resultsList) {
             results = parsedResults[0];
           }
+
+          // Parse the summary row if it exists
+          if (typeof results.summaryRow !== "undefined") {
+            const parsedSummaryRow = formatCallResults([results.summaryRow], results.fieldMask);
+            if (parsedSummaryRow && parsedSummaryRow.length >= 0) {
+              results.summaryRow = parsedSummaryRow[0];
+            }
+          }
+
           next(results);
         } else {
           next(message);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
If specifying `parseResults` and `summaryRowSetting`, the results of the summary wouldn't be parsed correctly.

- **What is the new behavior (if this is a feature change)?**
This ensures the summary row is parsed if specified in a query.

* **Other information**:
This PR is required to add support for the summary row in google-ads-api.