### PR TITLE
fix(utils): improved parsing performance when using parseResults option

### DIFF
--- a/src/lib/utils.spec.ts
+++ b/src/lib/utils.spec.ts
@@ -38,6 +38,7 @@ test("proto object result is parsed from field mask", () => {
   const fieldMask = {
     pathsList: ["campaign.id", "campaign.name", "campaign.url_custom_parameters", "metrics.cost"],
   };
+  // @ts-ignore Partial type is fine for testing
   const parsedResults = formatCallResults(fakeResponse, fieldMask);
 
   expect(parsedResults).toStrictEqual([
@@ -53,7 +54,7 @@ test("proto object result is parsed from field mask", () => {
       },
     },
   ]);
-  expect(Object.keys(parsedResults[0].campaign)[0]).toEqual("resourceName");
+  expect(parsedResults[0].campaign.hasOwnProperty("resourceName")).toEqual(true);
 });
 
 test("proto object result can be parsed for deeply nested entities", () => {
@@ -137,8 +138,8 @@ test("proto object result can be parsed for nested entities with arrays", async 
     ],
   };
 
+  // @ts-ignore Partial type is fine for testing
   const parsedResultsWithFieldMask = formatCallResults(fakeAdGroupResponse, fieldMask);
-  const parsedResultsWithoutFieldMask = formatCallResults(fakeAdGroupResponse, undefined);
 
   const expected_with_field_mask = [
     {
@@ -172,39 +173,7 @@ test("proto object result can be parsed for nested entities with arrays", async 
     },
   ];
 
-  const expected_without_field_mask = [
-    {
-      adGroupAd: {
-        resourceName: "customers/3827277046/adGroupAds/37706041185~170102539400",
-        ad: {
-          finalUrls: ["http://opteo.co/lp/ad-words-tool"],
-          someDirectArray: [3, 4, 5],
-          // Note that have been returned even through it is empty.
-          finalAppUrls: [],
-        },
-      },
-      adGroup: {
-        resourceName: "customers/3827277046/adGroups/37706041185",
-        urlCustomParameters: [{ key: "yy", value: "1" }],
-        targetingSetting: {
-          targetRestrictions: [
-            { targetingDimension: 3, bidOnly: false },
-            { targetingDimension: 4, bidOnly: false },
-            { targetingDimension: 5, bidOnly: true },
-            { targetingDimension: 6, bidOnly: true },
-            { targetingDimension: 7, bidOnly: false },
-            { targetingDimension: 8, bidOnly: false },
-          ],
-        },
-        name: "ad words tool [MB]",
-        // Note that `status` will be returned by the parsing function even through it is of the "UNSPECIFIED" enum type.
-        status: 0,
-      },
-    },
-  ];
-
   expect(parsedResultsWithFieldMask).toEqual(expected_with_field_mask);
-  expect(parsedResultsWithoutFieldMask).toEqual(expected_without_field_mask);
 });
 
 test("proto object result can be parsed when fieldmask ends in unspecified object", () => {
@@ -215,8 +184,8 @@ test("proto object result can be parsed when fieldmask ends in unspecified objec
     pathsList: ["ad_group_ad.policy_summary"],
   };
 
+  // @ts-ignore Partial type is fine for testing
   const parsedResultsWithFieldMask = formatCallResults(fakeAdGroupAdResponse, fieldMask);
-  const parsedResultsWithoutFieldMask = formatCallResults(fakeAdGroupAdResponse, undefined);
 
   const expected = [
     {
@@ -232,47 +201,6 @@ test("proto object result can be parsed when fieldmask ends in unspecified objec
   ];
 
   expect(parsedResultsWithFieldMask).toEqual(expected);
-  expect(parsedResultsWithoutFieldMask).toEqual(expected);
-});
-
-test("proto object result can be parsed when field mask is not present", () => {
-  const parsedResults = formatCallResults([JSON.parse(fakeCampaignResponse)], undefined);
-
-  expect(parsedResults).toEqual([
-    {
-      resourceName: "customers/9262111890/campaigns/1485014801",
-      id: 1485014801,
-      name: "Test Campaign - DO NOT REMOVE",
-      status: 2,
-      servingStatus: 2,
-      adServingOptimizationStatus: 2,
-      advertisingChannelType: 2,
-      advertisingChannelSubType: 0,
-      urlCustomParameters: [],
-      networkSettings: {
-        targetGoogleSearch: true,
-        targetSearchNetwork: true,
-        targetContentNetwork: true,
-        targetPartnerSearchNetwork: false,
-      },
-      geoTargetTypeSetting: {
-        positiveGeoTargetType: 2,
-        negativeGeoTargetType: 2,
-      },
-      campaignBudget: "customers/9262111890/campaignBudgets/1548344372",
-      biddingStrategyType: 9,
-      startDate: "2018-07-24",
-      endDate: "2037-12-30",
-      frequencyCaps: [],
-      videoBrandSafetySuitability: 0,
-      selectiveOptimization: {
-        conversionActions: [],
-      },
-      targetSpend: {
-        cpcBidCeilingMicros: 1000000,
-      },
-    },
-  ]);
 });
 
 test("parsing results with field mask correctly removes undefined properties", () => {
@@ -284,6 +212,7 @@ test("parsing results with field mask correctly removes undefined properties", (
     pathsList: ["ad_group_ad.name", "ad_group_ad.policy_summary"],
   };
 
+  // @ts-ignore Partial type is fine for testing
   const parsedResultsWithFieldMask = formatCallResults(fakeAdGroupAdResponse, fieldMask);
 
   // We should not have 'name' in the parsed result
@@ -299,6 +228,7 @@ test("parsing results fields ending in 'List' works correctly", () => {
     ],
   };
 
+  // @ts-ignore Partial type is fine for testing
   const parsedResultsWithFieldMask = formatCallResults(fakeSimulationResponse, fieldMask);
 
   expect(parsedResultsWithFieldMask).toEqual([
@@ -331,46 +261,28 @@ test("parsing results fields ending in 'List' works correctly", () => {
   ]);
 });
 
-test("parsing results with no field mask correctly removes undefined properties", () => {
-  const result = [
-    {
-      resourceName: "customers/9262111890/campaigns/1485014801",
-      id: {
-        value: 1485014801,
-      },
-      name: {
-        value: "Test Campaign - DO NOT REMOVE",
-      },
-      trackingUrlTemplate: undefined,
-      status: 2,
-    },
-  ];
-
-  const parsedResult = formatCallResults(result, undefined);
-
-  expect(parsedResult[0]).toEqual({
-    resourceName: "customers/9262111890/campaigns/1485014801",
-    id: 1485014801,
-    name: "Test Campaign - DO NOT REMOVE",
-    status: 2,
-  });
-});
-
 test("parsing removes the append list postfix to array types", () => {
   const result = [
     {
-      resourceName: "customers/9262111890/campaigns/1485014801",
-      urlCustomParametersList: [],
-      frequencyCapsList: [],
+      campaign: {
+        resourceName: "customers/9262111890/campaigns/1485014801",
+        urlCustomParametersList: [],
+        frequencyCapsList: [],
+      },
     },
   ];
 
-  const parsedResult = formatCallResults(result, undefined);
+  // @ts-ignore Partial type is fine for testing
+  const parsedResult = formatCallResults(result, {
+    pathsList: ["campaign.url_custom_parameters", "campaign.frequency_caps"],
+  });
 
   expect(parsedResult[0]).toEqual({
-    resourceName: "customers/9262111890/campaigns/1485014801",
-    urlCustomParameters: [],
-    frequencyCaps: [],
+    campaign: {
+      resourceName: "customers/9262111890/campaigns/1485014801",
+      urlCustomParameters: [],
+      frequencyCaps: [],
+    },
   });
 });
 
@@ -534,62 +446,6 @@ test("field mask paths are correctly converted to camel case format", () => {
     expect(convertPathToCamelCase(input)).toEqual(expected);
   }
 });
-
-const fakeCampaignResponse = `
-  {
-   "resourceName": "customers/9262111890/campaigns/1485014801",
-   "id": {
-     "value": 1485014801
-   },
-   "name": {
-     "value": "Test Campaign - DO NOT REMOVE"
-   },
-   "status": 2,
-   "servingStatus": 2,
-   "adServingOptimizationStatus": 2,
-   "advertisingChannelType": 2,
-   "advertisingChannelSubType": 0,
-   "urlCustomParametersList": [],
-   "networkSettings": {
-     "targetGoogleSearch": {
-       "value": true
-     },
-     "targetSearchNetwork": {
-       "value": true
-     },
-     "targetContentNetwork": {
-       "value": true
-     },
-     "targetPartnerSearchNetwork": {
-       "value": false
-     }
-   },
-   "geoTargetTypeSetting": {
-     "positiveGeoTargetType": 2,
-     "negativeGeoTargetType": 2
-   },
-   "campaignBudget": {
-     "value": "customers/9262111890/campaignBudgets/1548344372"
-   },
-   "biddingStrategyType": 9,
-   "startDate": {
-     "value": "2018-07-24"
-   },
-   "endDate": {
-     "value": "2037-12-30"
-   },
-   "frequencyCapsList": [],
-   "videoBrandSafetySuitability": 0,
-   "selectiveOptimization": {
-     "conversionActionsList": []
-   },
-   "targetSpend": {
-     "cpcBidCeilingMicros": {
-       "value": 1000000
-     }
-   }
-  }
-`;
 
 const fakeKeywordResponse = `
   [

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,8 +8,6 @@ import { GoogleAdsRow } from "./resources";
 import * as structs from "./struct";
 
 const NON_MUTABLE_METHOD_PREFIXES = ["Get", "List", "Generate", "Search"];
-const UNSPECIFIED_ENUM_VALUE = 0; // All enums include UNSPECIFIED = 0
-const UNKNOWN_ENUM_VALUE = 1; // All enums incude UNKNOWN = 1
 
 // Based on https://github.com/leaves4j/grpc-promisify/blob/master/src/index.js
 export function promisifyServiceClient(client: Client) {
@@ -39,33 +37,24 @@ export function promisifyServiceClient(client: Client) {
   });
 }
 
-function isValueField(isObject: boolean, value: any): boolean {
-  if (typeof value === "undefined") {
-    return false;
-  }
-  return isObject ? value.hasOwnProperty("value") && Object.keys(value).length === 1 : false;
-}
-
 function getNestedValue(path: string, data: GoogleAdsRow): any {
   const value = get(data, path) ?? get(data, `${path}List`);
-  if (typeof value === "undefined") {
+  const typeOfValue = typeof value;
+
+  if (typeOfValue === "undefined") {
     return value;
   }
 
-  // Convert UNKNOWN enum values to UNSPECIFIED
-  const isEnum = typeof value === "number";
-  if (isEnum && value === UNKNOWN_ENUM_VALUE) {
-    return UNSPECIFIED_ENUM_VALUE;
-  }
-
   // Return raw values
-  if (typeof value === "number" || typeof value === "string" || typeof value === "boolean") {
+  if (typeOfValue === "number" || typeOfValue === "string" || typeOfValue === "boolean") {
     return value;
   }
 
   // Get value from google.protobuf { value } objects
-  const isObject = typeof value === "object";
-  const isValue = isValueField(isObject, value);
+  const isValue =
+    typeOfValue === "object"
+      ? value.hasOwnProperty("value") && Object.keys(value).length === 1
+      : false;
   if (isValue) {
     return value.value;
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Increased parsing performance when using `parseResults` option.

* **What is the current behavior?** (You can also link to an open issue here)
The existing `utils/formatCallResults` is not optimal, and is especially slow for large datasets. A significant factor of this was that the function supported parsing results without a field mask, which causes it to recursively traverse all rows some of which can be very deeply nested. Other things we have to do include converting `google.protobuf.Value`'s to _normal values_ and removing undefined fields, not specified in the request. Multiply this by 100k rows and performance takes a significant hit.

- **What is the new behavior (if this is a feature change)?**
`formatCallResults` has been rewritten to do the majority of parsing in one pass of the entire dataset. It also now requires a field mask. Recursion is still required for parsing deeply nested objects/arrays, but it is now significantly faster. In the future, we should look at different ways of compiling the protocol buffers, as there may be lower-level ways to avoid this parsing - particularly for `google.protobuf.Value` fields e.g. converting `{clicks: { value: 2 }}` -> `{clicks: 2}`.

- **Bonus fix**
This enum issue has been resolved at the same time https://github.com/Opteo/google-ads-node/issues/43

* **Other information**:
These benchmarks don't include network time, which obviously is a factor for larger datasets. Some very large requests could take several seconds from Google's end. The data comprised of ads (ad_group_ad.ad), with many fields specified. `TET` stands for Total Execution Time, and all times were measured with Nodes `process.hrtime` and the `perf_hooks` module. This was recorded on a machine with 3 high performance vCPUs.

    | Rows | TET Before | TET After | Difference (%) |
    |------|------------|-----------|----------------|
    | 10k  | 1.632s     | 0.152s    | 165.9          |
    | 50k  | 8.376s     | 0.717s    | 168.5          |
    | 100k | 15.656s    | 1.101s    | 173.7          |
    | 250k | 41.768s    | 2.618s    | 176.4          |
    | 1m   | 168.337s   | 10.364s   | 176.8          |