### PR TITLE
fix(interceptor): parse summary row when no results exist

### DIFF
--- a/src/lib/interceptor.ts
+++ b/src/lib/interceptor.ts
@@ -256,13 +256,13 @@ export class ResponseParsingInterceptor {
             if (!results.partialFailureError && parsedResults && !results.resultsList) {
               results = parsedResults[0];
             }
+          }
 
-            // Parse the summary row if it exists
-            if (results.summaryRow && typeof results.summaryRow !== "undefined") {
-              const parsedSummaryRow = formatCallResults([results.summaryRow], results.fieldMask);
-              if (parsedSummaryRow && parsedSummaryRow.length >= 0) {
-                results.summaryRow = parsedSummaryRow[0];
-              }
+          // Parse the summary row if it exists
+          if (results.summaryRow && typeof results.summaryRow !== "undefined") {
+            const parsedSummaryRow = formatCallResults([results.summaryRow], results.fieldMask);
+            if (parsedSummaryRow && parsedSummaryRow.length >= 0) {
+              results.summaryRow = parsedSummaryRow[0];
             }
           }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
The summary row isn't parsed when specifiying `SummaryRowSetting` AND using `parseResults: true`

- **What is the new behavior (if this is a feature change)?**
It's now parsed. This was a bug introduced from our recent performance enhancements.

* **Other information**:
The diff is a bit unreadable, but essentially the summary row check has been moved from outside the `resultsList.length > 0` condition.