### PR TITLE
deps: upgraded google-gax to enable legacy proto load

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "sh ./init.sh"
   },
   "dependencies": {
-    "google-gax": "^2.19.0"
+    "google-gax": "^2.21.1"
   },
   "devDependencies": {
     "prettier": "^2.2.1",

--- a/package/googleads-nodejs/package.json
+++ b/package/googleads-nodejs/package.json
@@ -158,7 +158,7 @@
   "scripts": {
     "clean": "gts clean",
     "compile": "tsc -p . && cp -r protos build/",
-    "compile-protos": "compileProtos src",
+    "compile-protos": "compileProtos --skip-json src",
     "docs": "jsdoc -c .jsdoc.js",
     "predocs-test": "npm run docs",
     "docs-test": "linkinator docs",
@@ -169,7 +169,7 @@
     "test": "c8 mocha build/test"
   },
   "devDependencies": {
-    "@types/mocha": "^8.2.2",
+    "@types/mocha": "^9.0.0",
     "@types/node": "^14.17.3",
     "@types/sinon": "^10.0.2",
     "c8": "^7.7.3",
@@ -178,7 +178,7 @@
     "jsdoc-fresh": "^1.1.0",
     "jsdoc-region-tag": "^1.1.0",
     "linkinator": "^2.13.6",
-    "mocha": "^8.4.0",
+    "mocha": "^9.0.2",
     "null-loader": "^4.0.1",
     "pack-n-play": "^1.0.0-2",
     "sinon": "^11.1.1",

--- a/package/googleads-nodejs/src/v8/accessible_bidding_strategy_service_client.ts
+++ b/package/googleads-nodejs/src/v8/accessible_bidding_strategy_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/accessible_bidding_strategy_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AccessibleBiddingStrategyServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AccessibleBiddingStrategyServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AccessibleBiddingStrategyServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AccessibleBiddingStrategyServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AccessibleBiddingStrategyServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/accessible_bidding_strategy_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AccessibleBiddingStrategyServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AccessibleBiddingStrategyService.
     this.accessibleBiddingStrategyServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AccessibleBiddingStrategyService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AccessibleBiddingStrategyService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/account_budget_proposal_service_client.ts
+++ b/package/googleads-nodejs/src/v8/account_budget_proposal_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/account_budget_proposal_service_client_config.json`.
@@ -53,8 +52,8 @@ export class AccountBudgetProposalServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -97,11 +96,6 @@ export class AccountBudgetProposalServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -110,8 +104,7 @@ export class AccountBudgetProposalServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -119,7 +112,7 @@ export class AccountBudgetProposalServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -145,16 +138,15 @@ export class AccountBudgetProposalServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/account_budget_proposal_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -580,8 +572,6 @@ export class AccountBudgetProposalServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AccountBudgetProposalService.
     this.accountBudgetProposalServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AccountBudgetProposalService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AccountBudgetProposalService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/account_budget_service_client.ts
+++ b/package/googleads-nodejs/src/v8/account_budget_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/account_budget_service_client_config.json`.
@@ -42,8 +41,8 @@ export class AccountBudgetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -86,11 +85,6 @@ export class AccountBudgetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -99,8 +93,7 @@ export class AccountBudgetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -108,7 +101,7 @@ export class AccountBudgetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -134,16 +127,15 @@ export class AccountBudgetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/account_budget_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -569,8 +561,6 @@ export class AccountBudgetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AccountBudgetService.
     this.accountBudgetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AccountBudgetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AccountBudgetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/account_link_service_client.ts
+++ b/package/googleads-nodejs/src/v8/account_link_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/account_link_service_client_config.json`.
@@ -41,8 +40,8 @@ export class AccountLinkServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -85,11 +84,6 @@ export class AccountLinkServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -98,8 +92,7 @@ export class AccountLinkServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -107,7 +100,7 @@ export class AccountLinkServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -133,16 +126,15 @@ export class AccountLinkServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/account_link_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -568,8 +560,6 @@ export class AccountLinkServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AccountLinkService.
     this.accountLinkServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AccountLinkService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AccountLinkService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_ad_asset_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_ad_asset_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_ad_asset_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupAdAssetViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupAdAssetViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupAdAssetViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupAdAssetViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupAdAssetViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_ad_asset_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupAdAssetViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupAdAssetViewService.
     this.adGroupAdAssetViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupAdAssetViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupAdAssetViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_ad_label_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_ad_label_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_ad_label_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupAdLabelServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupAdLabelServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupAdLabelServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupAdLabelServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupAdLabelServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_ad_label_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupAdLabelServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupAdLabelService.
     this.adGroupAdLabelServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupAdLabelService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupAdLabelService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_ad_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_ad_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_ad_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupAdServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupAdServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupAdServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupAdServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupAdServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_ad_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupAdServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupAdService.
     this.adGroupAdServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupAdService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupAdService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_asset_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_asset_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_asset_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupAssetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupAssetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupAssetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupAssetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupAssetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_asset_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupAssetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupAssetService.
     this.adGroupAssetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupAssetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupAssetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_audience_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_audience_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_audience_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupAudienceViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupAudienceViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupAudienceViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupAudienceViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupAudienceViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_audience_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupAudienceViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupAudienceViewService.
     this.adGroupAudienceViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupAudienceViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupAudienceViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_bid_modifier_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_bid_modifier_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_bid_modifier_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupBidModifierServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupBidModifierServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupBidModifierServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupBidModifierServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupBidModifierServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_bid_modifier_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupBidModifierServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupBidModifierService.
     this.adGroupBidModifierServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupBidModifierService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupBidModifierService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_criterion_label_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_criterion_label_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_criterion_label_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupCriterionLabelServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupCriterionLabelServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupCriterionLabelServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupCriterionLabelServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupCriterionLabelServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_criterion_label_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupCriterionLabelServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupCriterionLabelService.
     this.adGroupCriterionLabelServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupCriterionLabelService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupCriterionLabelService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_criterion_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_criterion_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_criterion_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupCriterionServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupCriterionServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupCriterionServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupCriterionServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupCriterionServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_criterion_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupCriterionServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupCriterionService.
     this.adGroupCriterionServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupCriterionService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupCriterionService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_criterion_simulation_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_criterion_simulation_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_criterion_simulation_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupCriterionSimulationServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupCriterionSimulationServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupCriterionSimulationServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupCriterionSimulationServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupCriterionSimulationServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_criterion_simulation_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupCriterionSimulationServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupCriterionSimulationService.
     this.adGroupCriterionSimulationServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupCriterionSimulationService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupCriterionSimulationService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_extension_setting_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_extension_setting_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_extension_setting_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupExtensionSettingServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupExtensionSettingServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupExtensionSettingServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupExtensionSettingServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupExtensionSettingServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_extension_setting_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupExtensionSettingServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupExtensionSettingService.
     this.adGroupExtensionSettingServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupExtensionSettingService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupExtensionSettingService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_feed_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_feed_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_feed_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupFeedServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupFeedServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupFeedServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupFeedServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupFeedServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_feed_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupFeedServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupFeedService.
     this.adGroupFeedServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupFeedService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupFeedService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_label_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_label_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_label_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupLabelServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupLabelServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupLabelServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupLabelServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupLabelServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_label_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupLabelServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupLabelService.
     this.adGroupLabelServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupLabelService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupLabelService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupService.
     this.adGroupServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_group_simulation_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_group_simulation_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_group_simulation_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdGroupSimulationServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdGroupSimulationServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdGroupSimulationServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdGroupSimulationServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdGroupSimulationServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_group_simulation_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdGroupSimulationServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdGroupSimulationService.
     this.adGroupSimulationServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdGroupSimulationService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdGroupSimulationService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_parameter_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_parameter_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_parameter_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdParameterServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdParameterServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdParameterServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdParameterServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdParameterServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_parameter_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdParameterServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdParameterService.
     this.adParameterServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdParameterService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdParameterService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_schedule_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_schedule_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_schedule_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdScheduleViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdScheduleViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdScheduleViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdScheduleViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdScheduleViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_schedule_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdScheduleViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdScheduleViewService.
     this.adScheduleViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdScheduleViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdScheduleViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/ad_service_client.ts
+++ b/package/googleads-nodejs/src/v8/ad_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/ad_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AdServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AdServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AdServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AdServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AdServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/ad_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AdServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AdService.
     this.adServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AdService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AdService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/age_range_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/age_range_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/age_range_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AgeRangeViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AgeRangeViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AgeRangeViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AgeRangeViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AgeRangeViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/age_range_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AgeRangeViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AgeRangeViewService.
     this.ageRangeViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AgeRangeViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AgeRangeViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/asset_field_type_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/asset_field_type_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/asset_field_type_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class AssetFieldTypeViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class AssetFieldTypeViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class AssetFieldTypeViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class AssetFieldTypeViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class AssetFieldTypeViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/asset_field_type_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class AssetFieldTypeViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AssetFieldTypeViewService.
     this.assetFieldTypeViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AssetFieldTypeViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AssetFieldTypeViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/asset_service_client.ts
+++ b/package/googleads-nodejs/src/v8/asset_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/asset_service_client_config.json`.
@@ -42,8 +41,8 @@ export class AssetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -86,11 +85,6 @@ export class AssetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -99,8 +93,7 @@ export class AssetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -108,7 +101,7 @@ export class AssetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -134,16 +127,15 @@ export class AssetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/asset_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -569,8 +561,6 @@ export class AssetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.AssetService.
     this.assetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.AssetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.AssetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/batch_job_service_client.ts
+++ b/package/googleads-nodejs/src/v8/batch_job_service_client.ts
@@ -16,14 +16,13 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/batch_job_service_client_config.json`.
@@ -42,8 +41,8 @@ export class BatchJobServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -87,11 +86,6 @@ export class BatchJobServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -100,8 +94,7 @@ export class BatchJobServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -109,7 +102,7 @@ export class BatchJobServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -135,16 +128,15 @@ export class BatchJobServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/batch_job_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -544,7 +536,10 @@ export class BatchJobServiceClient {
           new this._gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'results')
     };
 
-    const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
+    let protoFilesRoot = new this._gaxModule.GoogleProtoFilesRoot();
+    protoFilesRoot = this._gaxModule.protobuf.loadSync(
+      path.join(__dirname, '..', '..', 'protos', 'google/ads/googleads/v8/services/batch_job_service.proto'),
+      protoFilesRoot) as (typeof protoFilesRoot);
 
     // This API contains "long-running operations", which return a
     // an Operation object that allows for tracking of the operation,
@@ -600,8 +595,6 @@ export class BatchJobServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.BatchJobService.
     this.batchJobServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.BatchJobService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.BatchJobService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/bidding_strategy_service_client.ts
+++ b/package/googleads-nodejs/src/v8/bidding_strategy_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/bidding_strategy_service_client_config.json`.
@@ -40,8 +39,8 @@ export class BiddingStrategyServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class BiddingStrategyServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class BiddingStrategyServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class BiddingStrategyServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class BiddingStrategyServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/bidding_strategy_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class BiddingStrategyServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.BiddingStrategyService.
     this.biddingStrategyServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.BiddingStrategyService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.BiddingStrategyService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/bidding_strategy_simulation_service_client.ts
+++ b/package/googleads-nodejs/src/v8/bidding_strategy_simulation_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/bidding_strategy_simulation_service_client_config.json`.
@@ -40,8 +39,8 @@ export class BiddingStrategySimulationServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class BiddingStrategySimulationServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class BiddingStrategySimulationServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class BiddingStrategySimulationServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class BiddingStrategySimulationServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/bidding_strategy_simulation_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class BiddingStrategySimulationServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.BiddingStrategySimulationService.
     this.biddingStrategySimulationServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.BiddingStrategySimulationService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.BiddingStrategySimulationService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/billing_setup_service_client.ts
+++ b/package/googleads-nodejs/src/v8/billing_setup_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/billing_setup_service_client_config.json`.
@@ -48,8 +47,8 @@ export class BillingSetupServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -92,11 +91,6 @@ export class BillingSetupServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -105,8 +99,7 @@ export class BillingSetupServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -114,7 +107,7 @@ export class BillingSetupServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -140,16 +133,15 @@ export class BillingSetupServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/billing_setup_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -575,8 +567,6 @@ export class BillingSetupServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.BillingSetupService.
     this.billingSetupServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.BillingSetupService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.BillingSetupService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_asset_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_asset_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_asset_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignAssetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignAssetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignAssetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignAssetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignAssetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_asset_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignAssetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignAssetService.
     this.campaignAssetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignAssetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignAssetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_audience_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_audience_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_audience_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignAudienceViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignAudienceViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignAudienceViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignAudienceViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignAudienceViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_audience_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignAudienceViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignAudienceViewService.
     this.campaignAudienceViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignAudienceViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignAudienceViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_bid_modifier_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_bid_modifier_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_bid_modifier_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignBidModifierServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignBidModifierServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignBidModifierServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignBidModifierServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignBidModifierServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_bid_modifier_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignBidModifierServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignBidModifierService.
     this.campaignBidModifierServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignBidModifierService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignBidModifierService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_budget_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_budget_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_budget_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignBudgetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignBudgetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignBudgetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignBudgetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignBudgetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_budget_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignBudgetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignBudgetService.
     this.campaignBudgetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignBudgetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignBudgetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_criterion_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_criterion_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_criterion_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignCriterionServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignCriterionServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignCriterionServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignCriterionServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignCriterionServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_criterion_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignCriterionServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignCriterionService.
     this.campaignCriterionServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignCriterionService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignCriterionService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_criterion_simulation_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_criterion_simulation_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_criterion_simulation_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignCriterionSimulationServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignCriterionSimulationServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignCriterionSimulationServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignCriterionSimulationServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignCriterionSimulationServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_criterion_simulation_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignCriterionSimulationServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignCriterionSimulationService.
     this.campaignCriterionSimulationServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignCriterionSimulationService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignCriterionSimulationService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_draft_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_draft_service_client.ts
@@ -16,14 +16,13 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_draft_service_client_config.json`.
@@ -42,8 +41,8 @@ export class CampaignDraftServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -87,11 +86,6 @@ export class CampaignDraftServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -100,8 +94,7 @@ export class CampaignDraftServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -109,7 +102,7 @@ export class CampaignDraftServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -135,16 +128,15 @@ export class CampaignDraftServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_draft_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -544,7 +536,10 @@ export class CampaignDraftServiceClient {
           new this._gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'errors')
     };
 
-    const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
+    let protoFilesRoot = new this._gaxModule.GoogleProtoFilesRoot();
+    protoFilesRoot = this._gaxModule.protobuf.loadSync(
+      path.join(__dirname, '..', '..', 'protos', 'google/ads/googleads/v8/services/campaign_draft_service.proto'),
+      protoFilesRoot) as (typeof protoFilesRoot);
 
     // This API contains "long-running operations", which return a
     // an Operation object that allows for tracking of the operation,
@@ -600,8 +595,6 @@ export class CampaignDraftServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignDraftService.
     this.campaignDraftServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignDraftService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignDraftService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_experiment_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_experiment_service_client.ts
@@ -16,14 +16,13 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation, PaginationCallback, GaxCall} from 'google-gax';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_experiment_service_client_config.json`.
@@ -51,8 +50,8 @@ export class CampaignExperimentServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -96,11 +95,6 @@ export class CampaignExperimentServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -109,8 +103,7 @@ export class CampaignExperimentServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -118,7 +111,7 @@ export class CampaignExperimentServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -144,16 +137,15 @@ export class CampaignExperimentServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_experiment_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -553,7 +545,10 @@ export class CampaignExperimentServiceClient {
           new this._gaxModule.PageDescriptor('pageToken', 'nextPageToken', 'errors')
     };
 
-    const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
+    let protoFilesRoot = new this._gaxModule.GoogleProtoFilesRoot();
+    protoFilesRoot = this._gaxModule.protobuf.loadSync(
+      path.join(__dirname, '..', '..', 'protos', 'google/ads/googleads/v8/services/campaign_experiment_service.proto'),
+      protoFilesRoot) as (typeof protoFilesRoot);
 
     // This API contains "long-running operations", which return a
     // an Operation object that allows for tracking of the operation,
@@ -617,8 +612,6 @@ export class CampaignExperimentServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignExperimentService.
     this.campaignExperimentServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignExperimentService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignExperimentService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_extension_setting_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_extension_setting_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_extension_setting_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignExtensionSettingServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignExtensionSettingServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignExtensionSettingServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignExtensionSettingServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignExtensionSettingServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_extension_setting_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignExtensionSettingServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignExtensionSettingService.
     this.campaignExtensionSettingServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignExtensionSettingService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignExtensionSettingService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_feed_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_feed_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_feed_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignFeedServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignFeedServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignFeedServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignFeedServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignFeedServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_feed_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignFeedServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignFeedService.
     this.campaignFeedServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignFeedService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignFeedService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_label_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_label_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_label_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignLabelServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignLabelServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignLabelServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignLabelServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignLabelServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_label_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignLabelServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignLabelService.
     this.campaignLabelServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignLabelService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignLabelService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignService.
     this.campaignServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_shared_set_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_shared_set_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_shared_set_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignSharedSetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignSharedSetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignSharedSetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignSharedSetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignSharedSetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_shared_set_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignSharedSetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignSharedSetService.
     this.campaignSharedSetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignSharedSetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignSharedSetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/campaign_simulation_service_client.ts
+++ b/package/googleads-nodejs/src/v8/campaign_simulation_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/campaign_simulation_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CampaignSimulationServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CampaignSimulationServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CampaignSimulationServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CampaignSimulationServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CampaignSimulationServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/campaign_simulation_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CampaignSimulationServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CampaignSimulationService.
     this.campaignSimulationServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CampaignSimulationService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CampaignSimulationService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/carrier_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/carrier_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/carrier_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CarrierConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CarrierConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CarrierConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CarrierConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CarrierConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/carrier_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CarrierConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CarrierConstantService.
     this.carrierConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CarrierConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CarrierConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/change_status_service_client.ts
+++ b/package/googleads-nodejs/src/v8/change_status_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/change_status_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ChangeStatusServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ChangeStatusServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ChangeStatusServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ChangeStatusServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ChangeStatusServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/change_status_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ChangeStatusServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ChangeStatusService.
     this.changeStatusServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ChangeStatusService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ChangeStatusService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/click_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/click_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/click_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ClickViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ClickViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ClickViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ClickViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ClickViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/click_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ClickViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ClickViewService.
     this.clickViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ClickViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ClickViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/combined_audience_service_client.ts
+++ b/package/googleads-nodejs/src/v8/combined_audience_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/combined_audience_service_client_config.json`.
@@ -42,8 +41,8 @@ export class CombinedAudienceServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -86,11 +85,6 @@ export class CombinedAudienceServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -99,8 +93,7 @@ export class CombinedAudienceServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -108,7 +101,7 @@ export class CombinedAudienceServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -134,16 +127,15 @@ export class CombinedAudienceServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/combined_audience_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -569,8 +561,6 @@ export class CombinedAudienceServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CombinedAudienceService.
     this.combinedAudienceServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CombinedAudienceService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CombinedAudienceService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/conversion_action_service_client.ts
+++ b/package/googleads-nodejs/src/v8/conversion_action_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/conversion_action_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ConversionActionServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ConversionActionServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ConversionActionServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ConversionActionServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ConversionActionServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/conversion_action_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ConversionActionServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ConversionActionService.
     this.conversionActionServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ConversionActionService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ConversionActionService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/conversion_adjustment_upload_service_client.ts
+++ b/package/googleads-nodejs/src/v8/conversion_adjustment_upload_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/conversion_adjustment_upload_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ConversionAdjustmentUploadServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ConversionAdjustmentUploadServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ConversionAdjustmentUploadServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ConversionAdjustmentUploadServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ConversionAdjustmentUploadServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/conversion_adjustment_upload_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ConversionAdjustmentUploadServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ConversionAdjustmentUploadService.
     this.conversionAdjustmentUploadServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ConversionAdjustmentUploadService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ConversionAdjustmentUploadService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/conversion_custom_variable_service_client.ts
+++ b/package/googleads-nodejs/src/v8/conversion_custom_variable_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/conversion_custom_variable_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ConversionCustomVariableServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ConversionCustomVariableServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ConversionCustomVariableServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ConversionCustomVariableServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ConversionCustomVariableServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/conversion_custom_variable_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ConversionCustomVariableServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ConversionCustomVariableService.
     this.conversionCustomVariableServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ConversionCustomVariableService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ConversionCustomVariableService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/conversion_upload_service_client.ts
+++ b/package/googleads-nodejs/src/v8/conversion_upload_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/conversion_upload_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ConversionUploadServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ConversionUploadServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ConversionUploadServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ConversionUploadServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ConversionUploadServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/conversion_upload_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ConversionUploadServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ConversionUploadService.
     this.conversionUploadServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ConversionUploadService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ConversionUploadService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/currency_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/currency_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/currency_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CurrencyConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CurrencyConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CurrencyConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CurrencyConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CurrencyConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/currency_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CurrencyConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CurrencyConstantService.
     this.currencyConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CurrencyConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CurrencyConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/custom_audience_service_client.ts
+++ b/package/googleads-nodejs/src/v8/custom_audience_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/custom_audience_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomAudienceServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomAudienceServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomAudienceServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomAudienceServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomAudienceServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/custom_audience_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomAudienceServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomAudienceService.
     this.customAudienceServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomAudienceService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomAudienceService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/custom_interest_service_client.ts
+++ b/package/googleads-nodejs/src/v8/custom_interest_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/custom_interest_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomInterestServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomInterestServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomInterestServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomInterestServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomInterestServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/custom_interest_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomInterestServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomInterestService.
     this.customInterestServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomInterestService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomInterestService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_asset_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_asset_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_asset_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerAssetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerAssetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerAssetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerAssetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerAssetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_asset_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerAssetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerAssetService.
     this.customerAssetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerAssetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerAssetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_client_link_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_client_link_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_client_link_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerClientLinkServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerClientLinkServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerClientLinkServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerClientLinkServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerClientLinkServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_client_link_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerClientLinkServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerClientLinkService.
     this.customerClientLinkServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerClientLinkService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerClientLinkService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_client_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_client_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_client_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerClientServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerClientServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerClientServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerClientServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerClientServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_client_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerClientServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerClientService.
     this.customerClientServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerClientService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerClientService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_extension_setting_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_extension_setting_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_extension_setting_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerExtensionSettingServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerExtensionSettingServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerExtensionSettingServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerExtensionSettingServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerExtensionSettingServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_extension_setting_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerExtensionSettingServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerExtensionSettingService.
     this.customerExtensionSettingServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerExtensionSettingService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerExtensionSettingService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_feed_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_feed_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_feed_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerFeedServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerFeedServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerFeedServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerFeedServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerFeedServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_feed_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerFeedServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerFeedService.
     this.customerFeedServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerFeedService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerFeedService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_label_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_label_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_label_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerLabelServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerLabelServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerLabelServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerLabelServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerLabelServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_label_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerLabelServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerLabelService.
     this.customerLabelServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerLabelService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerLabelService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_manager_link_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_manager_link_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_manager_link_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerManagerLinkServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerManagerLinkServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerManagerLinkServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerManagerLinkServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerManagerLinkServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_manager_link_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerManagerLinkServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerManagerLinkService.
     this.customerManagerLinkServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerManagerLinkService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerManagerLinkService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_negative_criterion_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_negative_criterion_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_negative_criterion_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerNegativeCriterionServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerNegativeCriterionServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerNegativeCriterionServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerNegativeCriterionServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerNegativeCriterionServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_negative_criterion_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerNegativeCriterionServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerNegativeCriterionService.
     this.customerNegativeCriterionServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerNegativeCriterionService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerNegativeCriterionService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerService.
     this.customerServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_user_access_invitation_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_user_access_invitation_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_user_access_invitation_service_client_config.json`.
@@ -41,8 +40,8 @@ export class CustomerUserAccessInvitationServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -85,11 +84,6 @@ export class CustomerUserAccessInvitationServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -98,8 +92,7 @@ export class CustomerUserAccessInvitationServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -107,7 +100,7 @@ export class CustomerUserAccessInvitationServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -133,16 +126,15 @@ export class CustomerUserAccessInvitationServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_user_access_invitation_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -568,8 +560,6 @@ export class CustomerUserAccessInvitationServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerUserAccessInvitationService.
     this.customerUserAccessInvitationServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerUserAccessInvitationService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerUserAccessInvitationService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/customer_user_access_service_client.ts
+++ b/package/googleads-nodejs/src/v8/customer_user_access_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/customer_user_access_service_client_config.json`.
@@ -40,8 +39,8 @@ export class CustomerUserAccessServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class CustomerUserAccessServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class CustomerUserAccessServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class CustomerUserAccessServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class CustomerUserAccessServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/customer_user_access_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class CustomerUserAccessServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.CustomerUserAccessService.
     this.customerUserAccessServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.CustomerUserAccessService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.CustomerUserAccessService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/detail_placement_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/detail_placement_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/detail_placement_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class DetailPlacementViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class DetailPlacementViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class DetailPlacementViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class DetailPlacementViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class DetailPlacementViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/detail_placement_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class DetailPlacementViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.DetailPlacementViewService.
     this.detailPlacementViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.DetailPlacementViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.DetailPlacementViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/detailed_demographic_service_client.ts
+++ b/package/googleads-nodejs/src/v8/detailed_demographic_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/detailed_demographic_service_client_config.json`.
@@ -40,8 +39,8 @@ export class DetailedDemographicServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class DetailedDemographicServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class DetailedDemographicServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class DetailedDemographicServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class DetailedDemographicServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/detailed_demographic_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class DetailedDemographicServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.DetailedDemographicService.
     this.detailedDemographicServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.DetailedDemographicService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.DetailedDemographicService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/display_keyword_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/display_keyword_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/display_keyword_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class DisplayKeywordViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class DisplayKeywordViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class DisplayKeywordViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class DisplayKeywordViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class DisplayKeywordViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/display_keyword_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class DisplayKeywordViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.DisplayKeywordViewService.
     this.displayKeywordViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.DisplayKeywordViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.DisplayKeywordViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/distance_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/distance_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/distance_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class DistanceViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class DistanceViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class DistanceViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class DistanceViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class DistanceViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/distance_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class DistanceViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.DistanceViewService.
     this.distanceViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.DistanceViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.DistanceViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/domain_category_service_client.ts
+++ b/package/googleads-nodejs/src/v8/domain_category_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/domain_category_service_client_config.json`.
@@ -40,8 +39,8 @@ export class DomainCategoryServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class DomainCategoryServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class DomainCategoryServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class DomainCategoryServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class DomainCategoryServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/domain_category_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class DomainCategoryServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.DomainCategoryService.
     this.domainCategoryServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.DomainCategoryService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.DomainCategoryService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/dynamic_search_ads_search_term_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/dynamic_search_ads_search_term_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/dynamic_search_ads_search_term_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class DynamicSearchAdsSearchTermViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class DynamicSearchAdsSearchTermViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class DynamicSearchAdsSearchTermViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class DynamicSearchAdsSearchTermViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class DynamicSearchAdsSearchTermViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/dynamic_search_ads_search_term_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class DynamicSearchAdsSearchTermViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.DynamicSearchAdsSearchTermViewService.
     this.dynamicSearchAdsSearchTermViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.DynamicSearchAdsSearchTermViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.DynamicSearchAdsSearchTermViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/expanded_landing_page_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/expanded_landing_page_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/expanded_landing_page_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ExpandedLandingPageViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ExpandedLandingPageViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ExpandedLandingPageViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ExpandedLandingPageViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ExpandedLandingPageViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/expanded_landing_page_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ExpandedLandingPageViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ExpandedLandingPageViewService.
     this.expandedLandingPageViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ExpandedLandingPageViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ExpandedLandingPageViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/extension_feed_item_service_client.ts
+++ b/package/googleads-nodejs/src/v8/extension_feed_item_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/extension_feed_item_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ExtensionFeedItemServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ExtensionFeedItemServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ExtensionFeedItemServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ExtensionFeedItemServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ExtensionFeedItemServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/extension_feed_item_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ExtensionFeedItemServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ExtensionFeedItemService.
     this.extensionFeedItemServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ExtensionFeedItemService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ExtensionFeedItemService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/feed_item_service_client.ts
+++ b/package/googleads-nodejs/src/v8/feed_item_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/feed_item_service_client_config.json`.
@@ -40,8 +39,8 @@ export class FeedItemServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class FeedItemServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class FeedItemServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class FeedItemServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class FeedItemServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/feed_item_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class FeedItemServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.FeedItemService.
     this.feedItemServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.FeedItemService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.FeedItemService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/feed_item_set_link_service_client.ts
+++ b/package/googleads-nodejs/src/v8/feed_item_set_link_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/feed_item_set_link_service_client_config.json`.
@@ -40,8 +39,8 @@ export class FeedItemSetLinkServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class FeedItemSetLinkServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class FeedItemSetLinkServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class FeedItemSetLinkServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class FeedItemSetLinkServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/feed_item_set_link_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class FeedItemSetLinkServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.FeedItemSetLinkService.
     this.feedItemSetLinkServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.FeedItemSetLinkService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.FeedItemSetLinkService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/feed_item_set_service_client.ts
+++ b/package/googleads-nodejs/src/v8/feed_item_set_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/feed_item_set_service_client_config.json`.
@@ -40,8 +39,8 @@ export class FeedItemSetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class FeedItemSetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class FeedItemSetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class FeedItemSetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class FeedItemSetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/feed_item_set_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class FeedItemSetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.FeedItemSetService.
     this.feedItemSetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.FeedItemSetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.FeedItemSetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/feed_item_target_service_client.ts
+++ b/package/googleads-nodejs/src/v8/feed_item_target_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/feed_item_target_service_client_config.json`.
@@ -40,8 +39,8 @@ export class FeedItemTargetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class FeedItemTargetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class FeedItemTargetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class FeedItemTargetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class FeedItemTargetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/feed_item_target_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class FeedItemTargetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.FeedItemTargetService.
     this.feedItemTargetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.FeedItemTargetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.FeedItemTargetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/feed_mapping_service_client.ts
+++ b/package/googleads-nodejs/src/v8/feed_mapping_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/feed_mapping_service_client_config.json`.
@@ -40,8 +39,8 @@ export class FeedMappingServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class FeedMappingServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class FeedMappingServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class FeedMappingServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class FeedMappingServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/feed_mapping_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class FeedMappingServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.FeedMappingService.
     this.feedMappingServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.FeedMappingService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.FeedMappingService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/feed_placeholder_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/feed_placeholder_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/feed_placeholder_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class FeedPlaceholderViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class FeedPlaceholderViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class FeedPlaceholderViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class FeedPlaceholderViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class FeedPlaceholderViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/feed_placeholder_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class FeedPlaceholderViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.FeedPlaceholderViewService.
     this.feedPlaceholderViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.FeedPlaceholderViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.FeedPlaceholderViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/feed_service_client.ts
+++ b/package/googleads-nodejs/src/v8/feed_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/feed_service_client_config.json`.
@@ -40,8 +39,8 @@ export class FeedServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class FeedServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class FeedServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class FeedServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class FeedServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/feed_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class FeedServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.FeedService.
     this.feedServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.FeedService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.FeedService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/gender_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/gender_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/gender_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class GenderViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class GenderViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class GenderViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class GenderViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class GenderViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/gender_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class GenderViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.GenderViewService.
     this.genderViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.GenderViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.GenderViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/geo_target_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/geo_target_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/geo_target_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class GeoTargetConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class GeoTargetConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class GeoTargetConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class GeoTargetConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class GeoTargetConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/geo_target_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class GeoTargetConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.GeoTargetConstantService.
     this.geoTargetConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.GeoTargetConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.GeoTargetConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/geographic_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/geographic_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/geographic_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class GeographicViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class GeographicViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class GeographicViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class GeographicViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class GeographicViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/geographic_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class GeographicViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.GeographicViewService.
     this.geographicViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.GeographicViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.GeographicViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/google_ads_field_service_client.ts
+++ b/package/googleads-nodejs/src/v8/google_ads_field_service_client.ts
@@ -16,14 +16,13 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/google_ads_field_service_client_config.json`.
@@ -42,8 +41,8 @@ export class GoogleAdsFieldServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -86,11 +85,6 @@ export class GoogleAdsFieldServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -99,8 +93,7 @@ export class GoogleAdsFieldServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -108,7 +101,7 @@ export class GoogleAdsFieldServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -134,16 +127,15 @@ export class GoogleAdsFieldServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/google_ads_field_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -577,8 +569,6 @@ export class GoogleAdsFieldServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.GoogleAdsFieldService.
     this.googleAdsFieldServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.GoogleAdsFieldService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.GoogleAdsFieldService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/google_ads_service_client.ts
+++ b/package/googleads-nodejs/src/v8/google_ads_service_client.ts
@@ -16,14 +16,13 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/google_ads_service_client_config.json`.
@@ -42,8 +41,8 @@ export class GoogleAdsServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -86,11 +85,6 @@ export class GoogleAdsServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -99,8 +93,7 @@ export class GoogleAdsServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -108,7 +101,7 @@ export class GoogleAdsServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -134,16 +127,15 @@ export class GoogleAdsServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/google_ads_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -583,8 +575,6 @@ export class GoogleAdsServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.GoogleAdsService.
     this.googleAdsServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.GoogleAdsService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.GoogleAdsService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/group_placement_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/group_placement_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/group_placement_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class GroupPlacementViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class GroupPlacementViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class GroupPlacementViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class GroupPlacementViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class GroupPlacementViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/group_placement_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class GroupPlacementViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.GroupPlacementViewService.
     this.groupPlacementViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.GroupPlacementViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.GroupPlacementViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/hotel_group_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/hotel_group_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/hotel_group_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class HotelGroupViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class HotelGroupViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class HotelGroupViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class HotelGroupViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class HotelGroupViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/hotel_group_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class HotelGroupViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.HotelGroupViewService.
     this.hotelGroupViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.HotelGroupViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.HotelGroupViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/hotel_performance_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/hotel_performance_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/hotel_performance_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class HotelPerformanceViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class HotelPerformanceViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class HotelPerformanceViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class HotelPerformanceViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class HotelPerformanceViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/hotel_performance_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class HotelPerformanceViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.HotelPerformanceViewService.
     this.hotelPerformanceViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.HotelPerformanceViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.HotelPerformanceViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/income_range_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/income_range_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/income_range_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class IncomeRangeViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class IncomeRangeViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class IncomeRangeViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class IncomeRangeViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class IncomeRangeViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/income_range_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class IncomeRangeViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.IncomeRangeViewService.
     this.incomeRangeViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.IncomeRangeViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.IncomeRangeViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/invoice_service_client.ts
+++ b/package/googleads-nodejs/src/v8/invoice_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/invoice_service_client_config.json`.
@@ -40,8 +39,8 @@ export class InvoiceServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class InvoiceServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class InvoiceServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class InvoiceServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class InvoiceServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/invoice_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class InvoiceServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.InvoiceService.
     this.invoiceServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.InvoiceService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.InvoiceService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/keyword_plan_ad_group_keyword_service_client.ts
+++ b/package/googleads-nodejs/src/v8/keyword_plan_ad_group_keyword_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/keyword_plan_ad_group_keyword_service_client_config.json`.
@@ -44,8 +43,8 @@ export class KeywordPlanAdGroupKeywordServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -88,11 +87,6 @@ export class KeywordPlanAdGroupKeywordServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -101,8 +95,7 @@ export class KeywordPlanAdGroupKeywordServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -110,7 +103,7 @@ export class KeywordPlanAdGroupKeywordServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -136,16 +129,15 @@ export class KeywordPlanAdGroupKeywordServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/keyword_plan_ad_group_keyword_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -571,8 +563,6 @@ export class KeywordPlanAdGroupKeywordServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.KeywordPlanAdGroupKeywordService.
     this.keywordPlanAdGroupKeywordServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.KeywordPlanAdGroupKeywordService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.KeywordPlanAdGroupKeywordService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/keyword_plan_ad_group_service_client.ts
+++ b/package/googleads-nodejs/src/v8/keyword_plan_ad_group_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/keyword_plan_ad_group_service_client_config.json`.
@@ -40,8 +39,8 @@ export class KeywordPlanAdGroupServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class KeywordPlanAdGroupServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class KeywordPlanAdGroupServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class KeywordPlanAdGroupServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class KeywordPlanAdGroupServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/keyword_plan_ad_group_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class KeywordPlanAdGroupServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.KeywordPlanAdGroupService.
     this.keywordPlanAdGroupServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.KeywordPlanAdGroupService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.KeywordPlanAdGroupService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/keyword_plan_campaign_keyword_service_client.ts
+++ b/package/googleads-nodejs/src/v8/keyword_plan_campaign_keyword_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/keyword_plan_campaign_keyword_service_client_config.json`.
@@ -43,8 +42,8 @@ export class KeywordPlanCampaignKeywordServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -87,11 +86,6 @@ export class KeywordPlanCampaignKeywordServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -100,8 +94,7 @@ export class KeywordPlanCampaignKeywordServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -109,7 +102,7 @@ export class KeywordPlanCampaignKeywordServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -135,16 +128,15 @@ export class KeywordPlanCampaignKeywordServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/keyword_plan_campaign_keyword_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -570,8 +562,6 @@ export class KeywordPlanCampaignKeywordServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.KeywordPlanCampaignKeywordService.
     this.keywordPlanCampaignKeywordServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.KeywordPlanCampaignKeywordService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.KeywordPlanCampaignKeywordService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/keyword_plan_campaign_service_client.ts
+++ b/package/googleads-nodejs/src/v8/keyword_plan_campaign_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/keyword_plan_campaign_service_client_config.json`.
@@ -40,8 +39,8 @@ export class KeywordPlanCampaignServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class KeywordPlanCampaignServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class KeywordPlanCampaignServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class KeywordPlanCampaignServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class KeywordPlanCampaignServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/keyword_plan_campaign_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class KeywordPlanCampaignServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.KeywordPlanCampaignService.
     this.keywordPlanCampaignServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.KeywordPlanCampaignService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.KeywordPlanCampaignService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/keyword_plan_idea_service_client.ts
+++ b/package/googleads-nodejs/src/v8/keyword_plan_idea_service_client.ts
@@ -16,14 +16,13 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, PaginationCallback, GaxCall} from 'google-gax';
 
 import { Transform } from 'stream';
 import { RequestType } from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/keyword_plan_idea_service_client_config.json`.
@@ -42,8 +41,8 @@ export class KeywordPlanIdeaServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -86,11 +85,6 @@ export class KeywordPlanIdeaServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -99,8 +93,7 @@ export class KeywordPlanIdeaServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -108,7 +101,7 @@ export class KeywordPlanIdeaServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -134,16 +127,15 @@ export class KeywordPlanIdeaServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/keyword_plan_idea_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -577,8 +569,6 @@ export class KeywordPlanIdeaServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.KeywordPlanIdeaService.
     this.keywordPlanIdeaServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.KeywordPlanIdeaService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.KeywordPlanIdeaService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/keyword_plan_service_client.ts
+++ b/package/googleads-nodejs/src/v8/keyword_plan_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/keyword_plan_service_client_config.json`.
@@ -40,8 +39,8 @@ export class KeywordPlanServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class KeywordPlanServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class KeywordPlanServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class KeywordPlanServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class KeywordPlanServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/keyword_plan_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class KeywordPlanServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.KeywordPlanService.
     this.keywordPlanServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.KeywordPlanService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.KeywordPlanService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/keyword_theme_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/keyword_theme_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/keyword_theme_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class KeywordThemeConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class KeywordThemeConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class KeywordThemeConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class KeywordThemeConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class KeywordThemeConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/keyword_theme_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class KeywordThemeConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.KeywordThemeConstantService.
     this.keywordThemeConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.KeywordThemeConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.KeywordThemeConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/keyword_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/keyword_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/keyword_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class KeywordViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class KeywordViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class KeywordViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class KeywordViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class KeywordViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/keyword_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class KeywordViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.KeywordViewService.
     this.keywordViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.KeywordViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.KeywordViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/label_service_client.ts
+++ b/package/googleads-nodejs/src/v8/label_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/label_service_client_config.json`.
@@ -40,8 +39,8 @@ export class LabelServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class LabelServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class LabelServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class LabelServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class LabelServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/label_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class LabelServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.LabelService.
     this.labelServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.LabelService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.LabelService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/landing_page_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/landing_page_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/landing_page_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class LandingPageViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class LandingPageViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class LandingPageViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class LandingPageViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class LandingPageViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/landing_page_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class LandingPageViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.LandingPageViewService.
     this.landingPageViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.LandingPageViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.LandingPageViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/language_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/language_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/language_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class LanguageConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class LanguageConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class LanguageConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class LanguageConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class LanguageConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/language_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class LanguageConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.LanguageConstantService.
     this.languageConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.LanguageConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.LanguageConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/life_event_service_client.ts
+++ b/package/googleads-nodejs/src/v8/life_event_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/life_event_service_client_config.json`.
@@ -40,8 +39,8 @@ export class LifeEventServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class LifeEventServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class LifeEventServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class LifeEventServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class LifeEventServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/life_event_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class LifeEventServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.LifeEventService.
     this.lifeEventServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.LifeEventService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.LifeEventService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/location_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/location_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/location_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class LocationViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class LocationViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class LocationViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class LocationViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class LocationViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/location_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class LocationViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.LocationViewService.
     this.locationViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.LocationViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.LocationViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/managed_placement_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/managed_placement_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/managed_placement_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ManagedPlacementViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ManagedPlacementViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ManagedPlacementViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ManagedPlacementViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ManagedPlacementViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/managed_placement_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ManagedPlacementViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ManagedPlacementViewService.
     this.managedPlacementViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ManagedPlacementViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ManagedPlacementViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/media_file_service_client.ts
+++ b/package/googleads-nodejs/src/v8/media_file_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/media_file_service_client_config.json`.
@@ -40,8 +39,8 @@ export class MediaFileServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class MediaFileServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class MediaFileServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class MediaFileServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class MediaFileServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/media_file_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class MediaFileServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.MediaFileService.
     this.mediaFileServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.MediaFileService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.MediaFileService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/merchant_center_link_service_client.ts
+++ b/package/googleads-nodejs/src/v8/merchant_center_link_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/merchant_center_link_service_client_config.json`.
@@ -41,8 +40,8 @@ export class MerchantCenterLinkServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -85,11 +84,6 @@ export class MerchantCenterLinkServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -98,8 +92,7 @@ export class MerchantCenterLinkServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -107,7 +100,7 @@ export class MerchantCenterLinkServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -133,16 +126,15 @@ export class MerchantCenterLinkServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/merchant_center_link_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -568,8 +560,6 @@ export class MerchantCenterLinkServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.MerchantCenterLinkService.
     this.merchantCenterLinkServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.MerchantCenterLinkService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.MerchantCenterLinkService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/mobile_app_category_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/mobile_app_category_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/mobile_app_category_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class MobileAppCategoryConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class MobileAppCategoryConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class MobileAppCategoryConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class MobileAppCategoryConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class MobileAppCategoryConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/mobile_app_category_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class MobileAppCategoryConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.MobileAppCategoryConstantService.
     this.mobileAppCategoryConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.MobileAppCategoryConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.MobileAppCategoryConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/mobile_device_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/mobile_device_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/mobile_device_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class MobileDeviceConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class MobileDeviceConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class MobileDeviceConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class MobileDeviceConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class MobileDeviceConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/mobile_device_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class MobileDeviceConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.MobileDeviceConstantService.
     this.mobileDeviceConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.MobileDeviceConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.MobileDeviceConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/offline_user_data_job_service_client.ts
+++ b/package/googleads-nodejs/src/v8/offline_user_data_job_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions, LROperation} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/offline_user_data_job_service_client_config.json`.
@@ -40,8 +39,8 @@ export class OfflineUserDataJobServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -85,11 +84,6 @@ export class OfflineUserDataJobServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -98,8 +92,7 @@ export class OfflineUserDataJobServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -107,7 +100,7 @@ export class OfflineUserDataJobServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -133,16 +126,15 @@ export class OfflineUserDataJobServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/offline_user_data_job_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -534,7 +526,10 @@ export class OfflineUserDataJobServiceClient {
       ),
     };
 
-    const protoFilesRoot = this._gaxModule.protobuf.Root.fromJSON(jsonProtos);
+    let protoFilesRoot = new this._gaxModule.GoogleProtoFilesRoot();
+    protoFilesRoot = this._gaxModule.protobuf.loadSync(
+      path.join(__dirname, '..', '..', 'protos', 'google/ads/googleads/v8/services/offline_user_data_job_service.proto'),
+      protoFilesRoot) as (typeof protoFilesRoot);
 
     // This API contains "long-running operations", which return a
     // an Operation object that allows for tracking of the operation,
@@ -590,8 +585,6 @@ export class OfflineUserDataJobServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.OfflineUserDataJobService.
     this.offlineUserDataJobServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.OfflineUserDataJobService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.OfflineUserDataJobService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/operating_system_version_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/operating_system_version_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/operating_system_version_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class OperatingSystemVersionConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class OperatingSystemVersionConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class OperatingSystemVersionConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class OperatingSystemVersionConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class OperatingSystemVersionConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/operating_system_version_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class OperatingSystemVersionConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.OperatingSystemVersionConstantService.
     this.operatingSystemVersionConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.OperatingSystemVersionConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.OperatingSystemVersionConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/paid_organic_search_term_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/paid_organic_search_term_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/paid_organic_search_term_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class PaidOrganicSearchTermViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class PaidOrganicSearchTermViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class PaidOrganicSearchTermViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class PaidOrganicSearchTermViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class PaidOrganicSearchTermViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/paid_organic_search_term_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class PaidOrganicSearchTermViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.PaidOrganicSearchTermViewService.
     this.paidOrganicSearchTermViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.PaidOrganicSearchTermViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.PaidOrganicSearchTermViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/parental_status_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/parental_status_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/parental_status_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ParentalStatusViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ParentalStatusViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ParentalStatusViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ParentalStatusViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ParentalStatusViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/parental_status_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ParentalStatusViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ParentalStatusViewService.
     this.parentalStatusViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ParentalStatusViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ParentalStatusViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/payments_account_service_client.ts
+++ b/package/googleads-nodejs/src/v8/payments_account_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/payments_account_service_client_config.json`.
@@ -41,8 +40,8 @@ export class PaymentsAccountServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -85,11 +84,6 @@ export class PaymentsAccountServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -98,8 +92,7 @@ export class PaymentsAccountServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -107,7 +100,7 @@ export class PaymentsAccountServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -133,16 +126,15 @@ export class PaymentsAccountServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/payments_account_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -568,8 +560,6 @@ export class PaymentsAccountServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.PaymentsAccountService.
     this.paymentsAccountServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.PaymentsAccountService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.PaymentsAccountService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/product_bidding_category_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/product_bidding_category_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/product_bidding_category_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ProductBiddingCategoryConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ProductBiddingCategoryConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ProductBiddingCategoryConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ProductBiddingCategoryConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ProductBiddingCategoryConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/product_bidding_category_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ProductBiddingCategoryConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ProductBiddingCategoryConstantService.
     this.productBiddingCategoryConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ProductBiddingCategoryConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ProductBiddingCategoryConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/product_group_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/product_group_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/product_group_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ProductGroupViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ProductGroupViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ProductGroupViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ProductGroupViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ProductGroupViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/product_group_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ProductGroupViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ProductGroupViewService.
     this.productGroupViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ProductGroupViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ProductGroupViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/reach_plan_service_client.ts
+++ b/package/googleads-nodejs/src/v8/reach_plan_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/reach_plan_service_client_config.json`.
@@ -44,8 +43,8 @@ export class ReachPlanServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -88,11 +87,6 @@ export class ReachPlanServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -101,8 +95,7 @@ export class ReachPlanServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -110,7 +103,7 @@ export class ReachPlanServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -136,16 +129,15 @@ export class ReachPlanServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/reach_plan_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -571,8 +563,6 @@ export class ReachPlanServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ReachPlanService.
     this.reachPlanServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ReachPlanService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ReachPlanService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/recommendation_service_client.ts
+++ b/package/googleads-nodejs/src/v8/recommendation_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/recommendation_service_client_config.json`.
@@ -40,8 +39,8 @@ export class RecommendationServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class RecommendationServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class RecommendationServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class RecommendationServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class RecommendationServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/recommendation_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class RecommendationServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.RecommendationService.
     this.recommendationServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.RecommendationService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.RecommendationService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/remarketing_action_service_client.ts
+++ b/package/googleads-nodejs/src/v8/remarketing_action_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/remarketing_action_service_client_config.json`.
@@ -40,8 +39,8 @@ export class RemarketingActionServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class RemarketingActionServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class RemarketingActionServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class RemarketingActionServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class RemarketingActionServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/remarketing_action_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class RemarketingActionServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.RemarketingActionService.
     this.remarketingActionServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.RemarketingActionService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.RemarketingActionService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/search_term_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/search_term_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/search_term_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class SearchTermViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class SearchTermViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class SearchTermViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class SearchTermViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class SearchTermViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/search_term_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class SearchTermViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.SearchTermViewService.
     this.searchTermViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.SearchTermViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.SearchTermViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/shared_criterion_service_client.ts
+++ b/package/googleads-nodejs/src/v8/shared_criterion_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/shared_criterion_service_client_config.json`.
@@ -40,8 +39,8 @@ export class SharedCriterionServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class SharedCriterionServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class SharedCriterionServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class SharedCriterionServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class SharedCriterionServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/shared_criterion_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class SharedCriterionServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.SharedCriterionService.
     this.sharedCriterionServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.SharedCriterionService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.SharedCriterionService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/shared_set_service_client.ts
+++ b/package/googleads-nodejs/src/v8/shared_set_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/shared_set_service_client_config.json`.
@@ -40,8 +39,8 @@ export class SharedSetServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class SharedSetServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class SharedSetServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class SharedSetServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class SharedSetServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/shared_set_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class SharedSetServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.SharedSetService.
     this.sharedSetServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.SharedSetService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.SharedSetService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/shopping_performance_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/shopping_performance_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/shopping_performance_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class ShoppingPerformanceViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class ShoppingPerformanceViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class ShoppingPerformanceViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class ShoppingPerformanceViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class ShoppingPerformanceViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/shopping_performance_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class ShoppingPerformanceViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ShoppingPerformanceViewService.
     this.shoppingPerformanceViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ShoppingPerformanceViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ShoppingPerformanceViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/smart_campaign_search_term_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/smart_campaign_search_term_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/smart_campaign_search_term_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class SmartCampaignSearchTermViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class SmartCampaignSearchTermViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class SmartCampaignSearchTermViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class SmartCampaignSearchTermViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class SmartCampaignSearchTermViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/smart_campaign_search_term_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class SmartCampaignSearchTermViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.SmartCampaignSearchTermViewService.
     this.smartCampaignSearchTermViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.SmartCampaignSearchTermViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.SmartCampaignSearchTermViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/smart_campaign_setting_service_client.ts
+++ b/package/googleads-nodejs/src/v8/smart_campaign_setting_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/smart_campaign_setting_service_client_config.json`.
@@ -40,8 +39,8 @@ export class SmartCampaignSettingServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class SmartCampaignSettingServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class SmartCampaignSettingServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class SmartCampaignSettingServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class SmartCampaignSettingServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/smart_campaign_setting_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class SmartCampaignSettingServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.SmartCampaignSettingService.
     this.smartCampaignSettingServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.SmartCampaignSettingService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.SmartCampaignSettingService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/smart_campaign_suggest_service_client.ts
+++ b/package/googleads-nodejs/src/v8/smart_campaign_suggest_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/smart_campaign_suggest_service_client_config.json`.
@@ -40,8 +39,8 @@ export class SmartCampaignSuggestServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class SmartCampaignSuggestServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class SmartCampaignSuggestServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class SmartCampaignSuggestServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class SmartCampaignSuggestServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/smart_campaign_suggest_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class SmartCampaignSuggestServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.SmartCampaignSuggestService.
     this.smartCampaignSuggestServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.SmartCampaignSuggestService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.SmartCampaignSuggestService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/third_party_app_analytics_link_service_client.ts
+++ b/package/googleads-nodejs/src/v8/third_party_app_analytics_link_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/third_party_app_analytics_link_service_client_config.json`.
@@ -41,8 +40,8 @@ export class ThirdPartyAppAnalyticsLinkServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -85,11 +84,6 @@ export class ThirdPartyAppAnalyticsLinkServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -98,8 +92,7 @@ export class ThirdPartyAppAnalyticsLinkServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -107,7 +100,7 @@ export class ThirdPartyAppAnalyticsLinkServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -133,16 +126,15 @@ export class ThirdPartyAppAnalyticsLinkServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/third_party_app_analytics_link_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -568,8 +560,6 @@ export class ThirdPartyAppAnalyticsLinkServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.ThirdPartyAppAnalyticsLinkService.
     this.thirdPartyAppAnalyticsLinkServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.ThirdPartyAppAnalyticsLinkService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.ThirdPartyAppAnalyticsLinkService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/topic_constant_service_client.ts
+++ b/package/googleads-nodejs/src/v8/topic_constant_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/topic_constant_service_client_config.json`.
@@ -40,8 +39,8 @@ export class TopicConstantServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class TopicConstantServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class TopicConstantServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class TopicConstantServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class TopicConstantServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/topic_constant_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class TopicConstantServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.TopicConstantService.
     this.topicConstantServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.TopicConstantService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.TopicConstantService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/topic_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/topic_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/topic_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class TopicViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class TopicViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class TopicViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class TopicViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class TopicViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/topic_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class TopicViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.TopicViewService.
     this.topicViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.TopicViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.TopicViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/user_data_service_client.ts
+++ b/package/googleads-nodejs/src/v8/user_data_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/user_data_service_client_config.json`.
@@ -41,8 +40,8 @@ export class UserDataServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -85,11 +84,6 @@ export class UserDataServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -98,8 +92,7 @@ export class UserDataServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -107,7 +100,7 @@ export class UserDataServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -133,16 +126,15 @@ export class UserDataServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/user_data_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -568,8 +560,6 @@ export class UserDataServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.UserDataService.
     this.userDataServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.UserDataService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.UserDataService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/user_interest_service_client.ts
+++ b/package/googleads-nodejs/src/v8/user_interest_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/user_interest_service_client_config.json`.
@@ -40,8 +39,8 @@ export class UserInterestServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class UserInterestServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class UserInterestServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class UserInterestServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class UserInterestServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/user_interest_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class UserInterestServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.UserInterestService.
     this.userInterestServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.UserInterestService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.UserInterestService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/user_list_service_client.ts
+++ b/package/googleads-nodejs/src/v8/user_list_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/user_list_service_client_config.json`.
@@ -40,8 +39,8 @@ export class UserListServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class UserListServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class UserListServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class UserListServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class UserListServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/user_list_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class UserListServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.UserListService.
     this.userListServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.UserListService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.UserListService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/user_location_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/user_location_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/user_location_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class UserLocationViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class UserLocationViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class UserLocationViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class UserLocationViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class UserLocationViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/user_location_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class UserLocationViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.UserLocationViewService.
     this.userLocationViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.UserLocationViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.UserLocationViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/video_service_client.ts
+++ b/package/googleads-nodejs/src/v8/video_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/video_service_client_config.json`.
@@ -40,8 +39,8 @@ export class VideoServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class VideoServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class VideoServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class VideoServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class VideoServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/video_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class VideoServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.VideoService.
     this.videoServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.VideoService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.VideoService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/package/googleads-nodejs/src/v8/webpage_view_service_client.ts
+++ b/package/googleads-nodejs/src/v8/webpage_view_service_client.ts
@@ -16,12 +16,11 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-/* global window */
 import * as gax from 'google-gax';
 import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 
 import * as protos from '../../protos/protos';
-import jsonProtos = require('../../protos/protos.json');
+import * as path from 'path';
 /**
  * Client JSON configuration object, loaded from
  * `src/v8/webpage_view_service_client_config.json`.
@@ -40,8 +39,8 @@ export class WebpageViewServiceClient {
   private _terminated = false;
   private _opts: ClientOptions;
   private _providedCustomServicePath: boolean;
-  private _gaxModule: typeof gax | typeof gax.fallback;
-  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _gaxModule: typeof gax;
+  private _gaxGrpc: gax.GrpcClient;
   private _protos: {};
   private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
@@ -84,11 +83,6 @@ export class WebpageViewServiceClient {
    *     API remote host.
    * @param {gax.ClientConfig} [options.clientConfig] - Client configuration override.
    *     Follows the structure of {@link gapicConfig}.
-   * @param {boolean} [options.fallback] - Use HTTP fallback mode.
-   *     In fallback mode, a special browser-compatible transport implementation is used
-   *     instead of gRPC transport. In browser context (if the `window` object is defined)
-   *     the fallback mode is enabled automatically; set `options.fallback` to `false`
-   *     if you need to override this behavior.
    */
   constructor(opts?: ClientOptions) {
     // Ensure that options include all the required fields.
@@ -97,8 +91,7 @@ export class WebpageViewServiceClient {
     this._providedCustomServicePath = !!(opts?.servicePath || opts?.apiEndpoint);
     const port = opts?.port || staticMembers.port;
     const clientConfig = opts?.clientConfig ?? {};
-    const fallback = opts?.fallback ?? (typeof window !== 'undefined' && typeof window?.fetch === 'function');
-    opts = Object.assign({servicePath, port, clientConfig, fallback}, opts);
+    opts = Object.assign({servicePath, port, clientConfig}, opts);
 
     // If scopes are unset in options and we're connecting to a non-default endpoint, set scopes just in case.
     if (servicePath !== staticMembers.servicePath && !('scopes' in opts)) {
@@ -106,7 +99,7 @@ export class WebpageViewServiceClient {
     }
 
     // Choose either gRPC or proto-over-HTTP implementation of google-gax.
-    this._gaxModule = opts.fallback ? gax.fallback : gax;
+    this._gaxModule = gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options sent to the client.
     this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
@@ -132,16 +125,15 @@ export class WebpageViewServiceClient {
     } else {
       clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
-    if (!opts.fallback) {
-      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
-    } else if (opts.fallback === 'rest' ) {
-      clientHeader.push(`rest/${this._gaxGrpc.grpcVersion}`);
-    }
+    clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
     // Load the applicable protos.
-    this._protos = this._gaxGrpc.loadProtoJSON(jsonProtos);
+    this._protos = this._gaxGrpc.loadProto(
+      path.join(__dirname, '..', '..', 'protos'),
+      'google/ads/googleads/v8/services/webpage_view_service.proto'
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -567,8 +559,6 @@ export class WebpageViewServiceClient {
     // Put together the "service stub" for
     // google.ads.googleads.v8.services.WebpageViewService.
     this.webpageViewServiceStub = this._gaxGrpc.createStub(
-        this._opts.fallback ?
-          (this._protos as protobuf.Root).lookupService('google.ads.googleads.v8.services.WebpageViewService') :
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (this._protos as any).google.ads.googleads.v8.services.WebpageViewService,
         this._opts, this._providedCustomServicePath) as Promise<{[method: string]: Function}>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,16 +3,16 @@
 
 
 "@grpc/grpc-js@~1.3.0":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.2.tgz#eae97e6daf5abd49a7818aadeca0744dfb1ebca1"
-  integrity sha512-UXepkOKCATJrhHGsxt+CGfpZy9zUn1q9mop5kfcXq1fBkTePxVNPOdnISlCbJFlCtld+pSLGyZCzr9/zVprFKA==
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.6.tgz#6e2d17610c2c8df0f6ceab0e1968f563df74b173"
+  integrity sha512-v7+LQFbqZKmd/Tvf5/j1Xlbq6jXL/4d+gUtm2TNX4QiEC3ELWADmGr2dGlUyLl6aKTuYfsN72vAsO5zmavYkEg==
   dependencies:
     "@types/node" ">=12.12.47"
 
 "@grpc/proto-loader@^0.6.1":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.6.2.tgz#412575f3ff5ef0a9b79d4ea12c08cba5601041cb"
-  integrity sha512-q2Qle60Ht2OQBCp9S5hv1JbI4uBBq6/mqSevFNK3ZEgRDBCAkWqZPUhD/K9gXOHrHKluliHiVq2L9sw1mVyAIg==
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.6.4.tgz#5438c0d771e92274e77e631babdc14456441cbdc"
+  integrity sha512-7xvDvW/vJEcmLUltCUGOgWRPM8Oofv0eCFSVMuKqaqWJaXSzmB+m9hiyqe34QofAl4WAzIKUZZlinIF9FOHyTQ==
   dependencies:
     "@types/long" "^4.0.1"
     lodash.camelcase "^4.3.0"
@@ -79,9 +79,9 @@
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
 "@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "15.12.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
-  integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
+  version "16.4.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.12.tgz#961e3091f263e6345d2d84afab4e047a60b4b11b"
+  integrity sha512-zxrTNFl9Z8boMJXs6ieqZP0wAhvkdzmHSxTlJabM16cf5G9xBc1uPRH5Bbv2omEDDiM8MzTfqTJXBf0Ba4xFWA==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -151,16 +151,16 @@ color-name@~1.1.4:
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 debug@4, debug@^4.1.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
 duplexify@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.1.tgz#7027dc374f157b122a8ae08c2d3ea4d2d953aa61"
-  integrity sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.2.tgz#18b4f8d28289132fa0b9573c898d9f903f81c7b0"
+  integrity sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==
   dependencies:
     end-of-stream "^1.4.1"
     inherits "^2.0.3"
@@ -231,9 +231,9 @@ get-caller-file@^2.0.5:
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 google-auth-library@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.3.0.tgz#946a911c72425b05f02735915f03410604466657"
-  integrity sha512-MPeeMlnsYnoiiVFMwX3hgaS684aiXrSqKoDP+xL4Ejg4Z0qLvIeg4XsaChemyFI8ZUO7ApwDAzNtgmhWSDNh5w==
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.5.0.tgz#6b0a623dfb4ee7a8d93a0d25455031d1baf86181"
+  integrity sha512-iRMwc060kiA6ncZbAoQN90nlwT8jiHVmippofpMgo4YFEyRBaPouyM7+ZB742wKetByyy+TahshVRTx0tEyXGQ==
   dependencies:
     arrify "^2.0.0"
     base64-js "^1.3.0"
@@ -245,10 +245,10 @@ google-auth-library@^7.3.0:
     jws "^4.0.0"
     lru-cache "^6.0.0"
 
-google-gax@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-2.19.0.tgz#e0e113f48688289e22053528224dfac09f019164"
-  integrity sha512-2a6WY+p6YMVMmwXmkRqiLreXx67xHDZhkmflcL8aDUkl1csx9ywxEI01veoDXy6T1l0JJD6zLbl5TIbWimmXrw==
+google-gax@^2.21.1:
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-2.21.1.tgz#393f18e950a594c8a2edb106271bbff4a24c0367"
+  integrity sha512-hyfau8+yXt75UuYVP3E3n0pKUwsEyiVQXfozfqQn/ZOL36UoZtS/cIzqIm6SYaSLlK5MWWz3JT/o/1ol09gEbA==
   dependencies:
     "@grpc/grpc-js" "~1.3.0"
     "@grpc/proto-loader" "^0.6.1"
@@ -260,13 +260,13 @@ google-gax@^2.19.0:
     is-stream-ended "^0.1.4"
     node-fetch "^2.6.1"
     object-hash "^2.1.1"
-    protobufjs "^6.10.2"
+    protobufjs "6.11.2"
     retry-request "^4.0.0"
 
 google-p12-pem@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.0.tgz#a1421b432fcc926812e3835289807170768a9885"
-  integrity sha512-JUtEHXL4DY/N+xhlm7TC3qL797RPAtk0ZGXNs3/gWyiDHYoA/8Rjes0pztkda+sZv4ej1EoO2KhWgW5V9KTrSQ==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.1.tgz#98fb717b722d12196a3e5b550c44517562269859"
+  integrity sha512-e9CwdD2QYkpvJsktki3Bm8P8FSGIneF+/42a9F9QHcQvJ73C2RoYZdrwRl6BhwksWtzl65gT4OnBROhUIFw95Q==
   dependencies:
     node-forge "^0.10.0"
 
@@ -303,9 +303,9 @@ is-stream-ended@^0.1.4:
   integrity sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==
 
 is-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
-  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 json-bigint@^1.0.0:
   version "1.0.0"
@@ -380,7 +380,7 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
-protobufjs@^6.10.0, protobufjs@^6.10.2:
+protobufjs@6.11.2, protobufjs@^6.10.0:
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
   integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
@@ -414,11 +414,12 @@ require-directory@^2.1.1:
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
 retry-request@^4.0.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-4.1.3.tgz#d5f74daf261372cff58d08b0a1979b4d7cab0fde"
-  integrity sha512-QnRZUpuPNgX0+D1xVxul6DbJ9slvo4Rm6iV/dn63e048MvGbUZiKySVt6Tenp04JqmchxjiLltGerOJys7kJYQ==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-4.2.2.tgz#b7d82210b6d2651ed249ba3497f07ea602f1a903"
+  integrity sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==
   dependencies:
     debug "^4.1.1"
+    extend "^3.0.2"
 
 safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"


### PR DESCRIPTION
- Upgraded google-gax to `2.21.1`
- Recompiled protos to enable new legacy proto load feature