### PR TITLE
fix(build): switch PWD -> CURDIR to allow Windows builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOOGLE_ADS_VERSION=v10
 
 BUNDLE=googleads-nodejs.tar.gz
 PACKAGE_BUILD=/package/googleads-nodejs
-PACKAGE_OUT=${PWD}/package/
+PACKAGE_OUT=${CURDIR}/package/
 
 protos: clean build copy
 


### PR DESCRIPTION
Windows builds were failing due to some quirks with how the `PWD` variable is resolved in makefiles.

Switched to `CURDIR` which has consistent behaviour cross-platform.

**Note:** on a PC without access to a Mac, so if someone could verify all is working as expected 🙏 

**`make protos` output before:**

```sh
docker cp gads:/package/googleads-nodejs /package/
docker rm gads
gads
chmod 700 /package/
chmod: cannot access '/package/': No such file or directory
make: *** [Makefile:15: copy] Error 1
```

**`make protos` output after:**

```sh
docker cp gads:/package/googleads-nodejs C:/dev/google-ads-node/package/
docker rm gads
gads
chmod 700 C:/dev/google-ads-node/package/
Bazel compiled protos output at C:/dev/google-ads-node/package/
```